### PR TITLE
Version bump of GCE Windows executables to 3.0.0.3

### DIFF
--- a/agent/Common/MetadataWatcher.cs
+++ b/agent/Common/MetadataWatcher.cs
@@ -72,7 +72,7 @@ namespace Common
     private static WebRequest CreateRequest(string metadataRequest)
     {
       HttpWebRequest request = WebRequest.CreateHttp(metadataRequest);
-      request.Headers.Add("X-Google-Metadata-Request", "True");
+      request.Headers.Add("Metadata-Flavor", "Google");
       request.Timeout = REQUEST_TIMEOUT;
       return request;
     }

--- a/agent/GCEMetadataScripts/Properties/AssemblyInfo.cs
+++ b/agent/GCEMetadataScripts/Properties/AssemblyInfo.cs
@@ -48,5 +48,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.0.0.2")]
-[assembly: AssemblyFileVersion("3.0.0.2")]
+[assembly: AssemblyVersion("3.0.0.3")]
+[assembly: AssemblyFileVersion("3.0.0.3")]

--- a/agent/GCEWindowsAgent/Properties/AssemblyInfo.cs
+++ b/agent/GCEWindowsAgent/Properties/AssemblyInfo.cs
@@ -48,5 +48,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.0.0.2")]
-[assembly: AssemblyFileVersion("3.0.0.2")]
+[assembly: AssemblyVersion("3.0.0.3")]
+[assembly: AssemblyFileVersion("3.0.0.3")]


### PR DESCRIPTION
Update the agent to use suggested headers.