### PR TITLE
Removed some bad string manipulation causing license status to get lost

### DIFF
--- a/gce/sysprep/instance_setup.ps1
+++ b/gce/sysprep/instance_setup.ps1
@@ -467,8 +467,7 @@ function Verify-ActivationStatus {
     return $active
   }
   # Check the output.
-  $activation_status = $slmgr_status.Split("`n") | Select-String -Pattern '^License Status:'
-  $status = $activation_status.Line.Remove(0,16)
+  $status = $slmgr_status.Split("`n") | Select-String -Pattern '^License Status:'
   Write-Log "Activation status - $status"
   if ($status -match "Licensed") {
     $active = $true


### PR DESCRIPTION
Previous string manipulation caused error (I don't think Line is defined?). Getting rid of it works, and allows the script to be able to tell that it licensed the copy of windows successfully. 