### PR TITLE
Add exception handling to GCEMetadataScripts.exe.

### DIFF
--- a/agent/GCEAgentInstaller/Installer.cs
+++ b/agent/GCEAgentInstaller/Installer.cs
@@ -113,12 +113,12 @@ namespace Google.ComputeEngine.Agent.Installer
                     }
                 }
             }
-            catch (Exception ex)
+            catch (Exception e)
             {
                 Logger.Error(
                     "Failed to install GCE Agent (version {0}). Exception: {1}.",
                     ReleaseVersion,
-                    ex.ToString());
+                    e.ToString());
                 return false;
             }
 
@@ -147,12 +147,12 @@ namespace Google.ComputeEngine.Agent.Installer
                     destination,
                     suffix: string.Empty);
             }
-            catch (Exception ex)
+            catch (Exception e)
             {
                 Logger.Error(
                     "Failed to install Sysprep (version {0}). Exception: {1}.",
                     ReleaseVersion,
-                    ex.ToString());
+                    e.ToString());
                 InstallerUtils.Rollback(sysprepFiles, destination);
                 return false;
             }
@@ -169,13 +169,13 @@ namespace Google.ComputeEngine.Agent.Installer
                 InstallerUtils.WriteUpdateStatsKey(ApplicationId);
                 InstallerUtils.WriteUpdateKey(ApplicationId, ReleaseVersion, ApplicationName);
             }
-            catch (Exception ex)
+            catch (Exception e)
             {
                 // This branch should never happen when the installer is
                 // executed by Omaha client.
                 // However, if a user run the installer manually and does not
                 // have access to HKLM, this step will fail.
-                Logger.Error("Failed to write registry. Exception: {0}.", ex.ToString());
+                Logger.Error("Failed to write registry. Exception: {0}.", e.ToString());
             }
         }
     }

--- a/agent/GCEMetadataScripts/ScriptManager.cs
+++ b/agent/GCEMetadataScripts/ScriptManager.cs
@@ -49,9 +49,16 @@ namespace Google.ComputeEngine.MetadataScripts
             }
 
             Logger.Info("Starting {0} scripts (version {1}).", this.scriptType, version);
-            MetadataJson metadata = MetadataWatcher.GetMetadata();
-            this.metadata = reader.GetScripts(metadata);
-            this.writer.SetScripts(this.metadata);
+            try
+            {
+                MetadataJson metadata = MetadataWatcher.GetMetadata();
+                this.metadata = reader.GetScripts(metadata);
+                this.writer.SetScripts(this.metadata);
+            }
+            catch (Exception e)
+            {
+                Logger.Error("Caught top level exception. {0}\r\n{1}", e.Message, e.StackTrace);
+            }
             Logger.Info("Finished running {0} scripts.", this.scriptType);
         }
 

--- a/agent/GCEWindowsAgent/Manager.cs
+++ b/agent/GCEWindowsAgent/Manager.cs
@@ -39,9 +39,9 @@ namespace Google.ComputeEngine.Agent
             MetadataWatcher.MetadataUpdateEvent += new MetadataWatcher.EventHandler(Synchronize);
         }
 
-        private void Synchronize(object sender, MetadataUpdateEventArgs e)
+        private void Synchronize(object sender, MetadataUpdateEventArgs update)
         {
-            bool enabled = this.reader.IsEnabled(e.Metadata);
+            bool enabled = this.reader.IsEnabled(update.Metadata);
             if (this.enabled != enabled) {
                 this.enabled = enabled;
                 Logger.Info("{0} status: {1}.", this.name, enabled ? "enabled" : "disabled");
@@ -51,16 +51,16 @@ namespace Google.ComputeEngine.Agent
             {
                 try
                 {
-                    T metadata = (T)reader.GetMetadata(e.Metadata);
+                    T metadata = (T)reader.GetMetadata(update.Metadata);
                     if (!reader.CompareMetadata(this.metadata, metadata))
                     {
                         this.metadata = metadata;
                         this.writer.SetMetadata(this.metadata);
                     }
                 }
-                catch (Exception ex)
+                catch (Exception e)
                 {
-                    Logger.Error("Caught top level exception. {0}\r\n{1}", ex.Message, ex.StackTrace);
+                    Logger.Error("Caught top level exception. {0}\r\n{1}", e.Message, e.StackTrace);
                 }
             }
         }


### PR DESCRIPTION
Exections thrown by a startup script shouldn't crash the executable.