### PR TITLE
_RunExternalCMD doesn't seem to like the args

### DIFF
--- a/gce/sysprep/instance_setup.ps1
+++ b/gce/sysprep/instance_setup.ps1
@@ -288,7 +288,7 @@ function Configure-WinRM {
     # with enhanced key usage object identifiers of Server Authentication and Client Authentication.
     # https://msdn.microsoft.com/en-us/library/windows/desktop/aa386968(v=vs.85).aspx
     $eku = "1.3.6.1.5.5.7.3.1,1.3.6.1.5.5.7.3.2"
-    _RunExternalCMD $script:gce_install_dir\tools\makecert.exe -r -a SHA1 -sk "$(hostname)" -n "CN=$(hostname)" -ss My -sr LocalMachine -eku $eku
+    & $script:gce_install_dir\tools\makecert.exe -r -a SHA1 -sk "$(hostname)" -n "CN=$(hostname)" -ss My -sr LocalMachine -eku $eku
     $cert = Get-ChildItem Cert:\LocalMachine\my | Where-Object {$_.Subject -eq "CN=$(hostname)"}
   }
   # Configure winrm HTTPS transport using the created cert.


### PR DESCRIPTION
For some reason the makecert args freak out _RunExternalCMD, I really should refactor _RunExternalCMD to handle this better but that can wait for the deprecation of gce_base.psm1.