### PR TITLE
Fix metadata scripts to run as 64bit

### DIFF
--- a/google-compute-engine-metadata-scripts.goospec
+++ b/google-compute-engine-metadata-scripts.goospec
@@ -1,6 +1,6 @@
 {
   "name": "google-compute-engine-metadata-scripts",
-  "version": "3.5.0@2",
+  "version": "3.5.1@0",
   "arch": "x86_64",
   "authors": "Google Inc.",
   "license": "http://www.apache.org/licenses/LICENSE-2.0",

--- a/metadata_scripts/GCEMetadataScripts/Properties/AssemblyInfo.cs
+++ b/metadata_scripts/GCEMetadataScripts/Properties/AssemblyInfo.cs
@@ -45,5 +45,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision
 // Numbers by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.5.0.0")]
-[assembly: AssemblyFileVersion("3.5.0.0")]
+[assembly: AssemblyVersion("3.5.1.0")]
+[assembly: AssemblyFileVersion("3.5.1.0")]

--- a/metadata_scripts/GCEMetadataScripts/ScriptWriter.cs
+++ b/metadata_scripts/GCEMetadataScripts/ScriptWriter.cs
@@ -46,7 +46,7 @@ namespace Google.ComputeEngine.MetadataScripts
         private ProcessStartInfo RunPowershell(string script)
         {
             string arguments = string.Format("-ExecutionPolicy ByPass -File {0}", script);
-            return GetProcStartInfo(@"C:\Windows\sysnative\WindowsPowerShell\v1.0\powershell.exe", arguments);
+            return GetProcStartInfo(@"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe", arguments);
         }
 
         private void LogScriptOutput(string suffix, string message)

--- a/metadata_scripts/run_startup_scripts.cmd
+++ b/metadata_scripts/run_startup_scripts.cmd
@@ -19,4 +19,4 @@ REM A scheduled task may only run for up to three days before termination.
 REM We execute the startup script asynchronously so it may run without
 REM this three day maximum runtime limitation.
 
-start "C:\Program Files\Google\Compute Engine\metadata_scripts\GCEMetadataScripts.exe" "startup"
+start "" "C:\Program Files\Google\Compute Engine\metadata_scripts\GCEMetadataScripts.exe" "startup"


### PR DESCRIPTION
As GCEMetadataScripts is now compiled for 64bit System32 needs to be used
Fix run_startup_scripts.cmd syntax