### PR TITLE
Update address manager for failover cluster with internal load balancer

### DIFF
--- a/GCEAgent/addresses.go
+++ b/GCEAgent/addresses.go
@@ -30,7 +30,9 @@ type addresses struct {
 }
 
 func (a *addresses) diff() bool {
-	return !reflect.DeepEqual(a.newMetadata.Instance.NetworkInterfaces, a.oldMetadata.Instance.NetworkInterfaces)
+	return !reflect.DeepEqual(a.newMetadata.Instance.NetworkInterfaces, a.oldMetadata.Instance.NetworkInterfaces) ||
+		a.newMetadata.Instance.Attributes.WSFCAddresses != a.oldMetadata.Instance.Attributes.WSFCAddresses ||
+		a.newMetadata.Instance.Attributes.EnableWSFC != a.oldMetadata.Instance.Attributes.EnableWSFC
 }
 
 func (a *addresses) disabled() bool {
@@ -66,6 +68,9 @@ func (a *addresses) set() error {
 	if err != nil {
 		return err
 	}
+
+	a.applyWSFCFilter()
+
 	for _, ni := range a.newMetadata.Instance.NetworkInterfaces {
 		mac, err := net.ParseMAC(ni.Mac)
 		if err != nil {
@@ -141,4 +146,39 @@ func (a *addresses) set() error {
 	}
 
 	return nil
+}
+
+// Filter out forwarded ips based on WSFC (Windows Failover Cluster Settings).
+// If EnableWSFC is set, all ips in the ForwardedIps will be ignore.
+// If WSFCAddresses is set, only ips in the lisft will be filtered out.
+// If both of attributes are set, logic will respect WSFCAddresses
+func (a *addresses) applyWSFCFilter() {
+	var wsfcAddrs []string
+	for _, wsfcAddr := range strings.Split(a.newMetadata.Instance.Attributes.WSFCAddresses, ",") {
+		if len(wsfcAddr) == 0 {
+			continue
+		} else if net.ParseIP(wsfcAddr) == nil {
+			logger.Errorln("ip address for wsfc is not in valid form", wsfcAddr)
+		} else {
+			wsfcAddrs = append(wsfcAddrs, wsfcAddr)
+		}
+	}
+
+	if len(wsfcAddrs) != 0 {
+		interfaces := a.newMetadata.Instance.NetworkInterfaces
+		for idx := range interfaces {
+			filteredList := interfaces[idx].ForwardedIps[:0]
+			for _, ip := range interfaces[idx].ForwardedIps {
+				if !containsString(ip, wsfcAddrs) {
+					filteredList = append(filteredList, ip)
+				}
+			}
+
+			interfaces[idx].ForwardedIps = filteredList
+		}
+	} else if a.newMetadata.Instance.Attributes.EnableWSFC {
+		for idx := range a.newMetadata.Instance.NetworkInterfaces {
+			a.newMetadata.Instance.NetworkInterfaces[idx].ForwardedIps = nil
+		}
+	}
 }

--- a/GCEAgent/metadata.go
+++ b/GCEAgent/metadata.go
@@ -91,6 +91,5 @@ func watchMetadata(ctx context.Context) (*metadataJSON, error) {
 		return nil, err
 	}
 	var metadata metadataJSON
-	writeSerial("COM1", md)
 	return &metadata, json.Unmarshal(md, &metadata)
 }

--- a/GCEAgent/metadata.go
+++ b/GCEAgent/metadata.go
@@ -55,6 +55,8 @@ type attributesJSON struct {
 	DisableAddressManager bool   `json:"disable-address-manager,string"`
 	DisableAgentUpdates   bool   `json:"disable-agent-updates,string"`
 	DisableAccountManager bool   `json:"disable-account-manager,string"`
+	EnableWSFC            bool   `json:"enable-wsfc,string"`
+	WSFCAddresses         string `json:"wsfc-addrs"`
 }
 
 func updateEtag(resp *http.Response) {
@@ -89,5 +91,6 @@ func watchMetadata(ctx context.Context) (*metadataJSON, error) {
 		return nil, err
 	}
 	var metadata metadataJSON
+	writeSerial("COM1", md)
 	return &metadata, json.Unmarshal(md, &metadata)
 }


### PR DESCRIPTION
if enable-wsfc or wsfc_addrs is set, address manager will:
- stop auto config forward ips.
- if any ip has been configured already, it will get removed from OS