### PR TITLE
Clear self signed RDP and WinRM certs during gcesysprep

### DIFF
--- a/GCEWindowsAgent/accounts.go
+++ b/GCEWindowsAgent/accounts.go
@@ -254,7 +254,7 @@ func (a *accounts) set() error {
 	for _, s := range strings.Split(a.newMetadata.Instance.Attributes.WindowsKeys, "\n") {
 		var key windowsKeyJSON
 		if err := json.Unmarshal([]byte(s), &key); err != nil {
-			if !containsString(s, badReg) {
+			if !containsString(s, badKeys) {
 				logger.Error(err)
 				badKeys = append(badKeys, s)
 			}

--- a/gce_base.psm1
+++ b/gce_base.psm1
@@ -616,7 +616,7 @@ function Write-Log {
     [Alias('warning')]
     [Switch] $is_warning
   )
-  $timestamp = $(Get-Date)
+  $timestamp = $(Get-Date -Format 'yyyy/MM/dd HH:mm:ss')
   try {
     # Add a boundary around an important message.
     if ($is_important) {

--- a/google-compute-engine-metadata-scripts.goospec
+++ b/google-compute-engine-metadata-scripts.goospec
@@ -1,6 +1,6 @@
 {
   "name": "google-compute-engine-metadata-scripts",
-  "version": "4.1.0@1",
+  "version": "4.1.0@2",
   "arch": "x86_64",
   "authors": "Google Inc.",
   "license": "http://www.apache.org/licenses/LICENSE-2.0",

--- a/google-compute-engine-sysprep.goospec
+++ b/google-compute-engine-sysprep.goospec
@@ -1,6 +1,6 @@
 {
   "name": "google-compute-engine-sysprep",
-  "version": "3.6.1@1",
+  "version": "3.6.2@1",
   "arch": "noarch",
   "authors": "Google Inc.",
   "license": "http://www.apache.org/licenses/LICENSE-2.0",
@@ -15,6 +15,7 @@
     "path": "sysprep_uninstall.ps1"
   },
   "releaseNotes": [
+    "3.6.2 - Clear self signed RDP and WinRM certs during gcesysprep",
     "3.6.1 - Print ready log then wait for activation to complete",
     "      - Use certgen to generate self signed certs if Import-PfxCertificate exists",
     "3.5.5 - Remove code trying to set @@servername for SQL",

--- a/metadata_scripts_install.ps1
+++ b/metadata_scripts_install.ps1
@@ -23,8 +23,8 @@ if ($path -notlike "*${install_dir}*") {
 & schtasks /create /tn GCEStartup /tr "'${install_dir}\run_startup_scripts.cmd'" /sc onstart /ru System /f
 
 $gpt_ini = "${env:SystemRoot}\System32\GroupPolicy\gpt.ini"
-$scripts_ini = "${env:SystemRoot}\System32\GroupPolicy\Machine\Scripts\scripts.ini""
-if (Test-Path $gpt_ini -or Test-Path $scripts_ini) {
+$scripts_ini = "${env:SystemRoot}\System32\GroupPolicy\Machine\Scripts\scripts.ini"
+if ((Test-Path $gpt_ini) -or (Test-Path $scripts_ini)) {
   return
 }
 

--- a/metadata_scripts_install.ps1
+++ b/metadata_scripts_install.ps1
@@ -28,6 +28,8 @@ if ((Test-Path $gpt_ini) -or (Test-Path $scripts_ini)) {
   return
 }
 
+New-Item -Type Directory -Path "${env:SystemRoot}\System32\GroupPolicy\Machine\Scripts" -ErrorAction SilentlyContinue
+
 @'
 [General]
 gPCMachineExtensionNames= [{42B5FAAE-6536-11D2-AE5A-0000F87571E3}{40B6664F-4972-11D1-A7CA-0000F87571E3}]

--- a/sysprep/sysprep.ps1
+++ b/sysprep/sysprep.ps1
@@ -167,6 +167,7 @@ try {
 
   Write-Log 'Setting new startup command.'
   Set-ItemProperty -Path HKLM:\SYSTEM\Setup -Name CmdLine -Value "`"$PSScriptRoot\windeploy.cmd`""
+
   Write-Log 'Forgetting persistent disks.'
   # While we are using the PersistAllDeviceInstalls setting to make boot faster on GCE, it's a
   # good idea to forget the disks so that online/offline settings aren't applied to different
@@ -175,8 +176,13 @@ try {
   if (Test-Path $disk_root) {
     Remove-Item -Path "$disk_root\*\Device Parameters\Partmgr" -Recurse -Force
   }
+
+  Write-Log 'Clearing self signed certs.'
+  Get-ChildItem 'Cert:\LocalMachine\Remote Desktop' | Where-Object {$_.Subject -eq $_.Issuer} | Remove-Item
+  Get-ChildItem 'Cert:\LocalMachine\My' | Where-Object {$_.Subject -eq $_.Issuer} | Remove-Item
+
   Write-Log 'Shutting down.'
-  Stop-Computer
+  shutdown /s /t 00
 }
 catch {
   _PrintError

--- a/sysprep/sysprep.ps1
+++ b/sysprep/sysprep.ps1
@@ -178,8 +178,11 @@ try {
   }
 
   Write-Log 'Clearing self signed certs.'
-  Get-ChildItem 'Cert:\LocalMachine\Remote Desktop' | Where-Object {$_.Subject -eq $_.Issuer} | Remove-Item
-  Get-ChildItem 'Cert:\LocalMachine\My' | Where-Object {$_.Subject -eq $_.Issuer} | Remove-Item
+  @('Cert:\LocalMachine\Remote Desktop', 'Cert:\LocalMachine\My') | ForEach-Object {
+    if (Test-Path $_) {
+      Get-ChildItem $_ | Where-Object {$_.Subject -eq $_.Issuer} | Remove-Item
+    }
+  }
 
   Write-Log 'Shutting down.'
   shutdown /s /t 00


### PR DESCRIPTION
Clear self signed RDP and WinRM certs during gcesysprep
Fixes to metadata scripts installer
Use a more standard timestamp format