### PR TITLE
Don't set min password length in instance setup, set mtu to 1460

### DIFF
--- a/google-compute-engine-sysprep.goospec
+++ b/google-compute-engine-sysprep.goospec
@@ -1,6 +1,6 @@
 {
   "name": "google-compute-engine-sysprep",
-  "version": "3.6.2@1",
+  "version": "3.6.3@1",
   "arch": "noarch",
   "authors": "Google Inc.",
   "license": "http://www.apache.org/licenses/LICENSE-2.0",

--- a/google-compute-engine-sysprep.goospec
+++ b/google-compute-engine-sysprep.goospec
@@ -15,6 +15,7 @@
     "path": "sysprep_uninstall.ps1"
   },
   "releaseNotes": [
+    "3.6.3 - Don't set min password length in instance setup, set mtu to 1460",
     "3.6.2 - Clear self signed RDP and WinRM certs during gcesysprep",
     "3.6.1 - Print ready log then wait for activation to complete",
     "      - Use certgen to generate self signed certs if Import-PfxCertificate exists",

--- a/sysprep/instance_setup.ps1
+++ b/sysprep/instance_setup.ps1
@@ -17,20 +17,11 @@
     Setup GCE instance.
 
   .DESCRIPTION
-    This powershell script setups a GCE instance during and post sysprep.
+    This powershell script setups a GCE instance post sysprep.
     Some of the task performed by the scripts are:
       Change the hostname to match the GCE hostname
       Disable default Administrator user
-      Cleanup eventviewer
-      Cleanup temp files
       Activate the GCE instance
-      Set up the administrative username and password
-  .EXAMPLE
-    instance_setup.ps1
-  .EXAMPLE
-    instance_setup.ps1 -specialize
-  .EXAMPLE
-    instance_setup.ps1 -test
 
   #requires -version 3.0
 #>
@@ -130,16 +121,12 @@ function Change-InstanceProperties {
 
   $netkvm = Get-WmiObject Win32_NetworkAdapter -filter "ServiceName = 'netkvm'"
 
-  # Set MTU to 1430.
-  _RunExternalCMD netsh interface ipv4 set interface $netkvm.NetConnectionID mtu=1430
-  Write-Log 'MTU set to 1430.'
+  _RunExternalCMD netsh interface ipv4 set interface $netkvm.NetConnectionID mtu=1460
+  Write-Log 'MTU set to 1460.'
 
   # Adding persistent route to metadata netblock via netkvm adapter.
   _RunExternalCMD route /p add 169.254.0.0 mask 255.255.0.0 0.0.0.0 if $netkvm.InterfaceIndex metric 1 -ErrorAction SilentlyContinue
   Write-Log 'Added persistent route to metadata netblock via netkvm adapter.'
-
-  # Set minimum password length.
-  _RunExternalCMD net accounts /MINPWLEN:8
 
   # Enable access to Windows administrative file share.
   Set-ItemProperty -Path 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System' `

--- a/sysprep/instance_setup.ps1
+++ b/sysprep/instance_setup.ps1
@@ -20,7 +20,6 @@
     This powershell script setups a GCE instance post sysprep.
     Some of the task performed by the scripts are:
       Change the hostname to match the GCE hostname
-      Disable default Administrator user
       Activate the GCE instance
 
   #requires -version 3.0
@@ -229,28 +228,6 @@ function Configure-WinRM {
 }
 
 
-function Disable-Administrator {
-  <#
-    .SYNOPSIS
-      Disables the default Administrator user.
-    .DESCRIPTION
-      This function gives the built-in "Administrator" account a random password
-      and disables it.
-  #>
-  try {
-    Write-Log 'Setting random password for Administrator account.'
-    $password = _GenerateRandomPassword
-    _RunExternalCMD net user Administrator $password
-    _RunExternalCMD net user Administrator /ACTIVE:NO
-    Write-Log 'Disabled Administrator account.'
-  }
-  catch {
-    _PrintError
-    Write-Log 'Failed to disable Administrator account.' -error
-  }
-}
-
-
 # Check if COM1 exists.
 if (-not ($global:write_to_serial)) {
   Write-Log 'COM1 does not exist on this machine. Logs will not be written to GCE console.' -warning
@@ -287,7 +264,6 @@ $PSHome\powershell.exe -NoProfile -NoLogo -ExecutionPolicy Unrestricted -File "$
 }
 else {
   $activate_job = Start-Job -FilePath $script:activate_instance_script_loc
-  Disable-Administrator
   Enable-RemoteDesktop
   Configure-WinRM
 

--- a/sysprep/instance_setup.ps1
+++ b/sysprep/instance_setup.ps1
@@ -277,7 +277,7 @@ $PSHome\powershell.exe -NoProfile -NoLogo -ExecutionPolicy Unrestricted -File "$
 
   try {
     # Call startup script during sysprep specialize phase.
-    _RunExternalCMD $script:metadata_script_loc 'specialize'
+    & $script:metadata_script_loc 'specialize'
   }
   catch {
     _PrintError

--- a/sysprep/sysprep.ps1
+++ b/sysprep/sysprep.ps1
@@ -19,10 +19,11 @@
     This powershell script runs some cleanup routines and goes through a
     checklist before performing a sysprep on a windows host the script is being
     executed. This ensure's that the instance is in a clean state before a
-    sysprep is initated.
+    sysprep is initiated.
     Some of the task performed by the scripts are:
       Cleanup temp files
       Cleanup eventviewer
+      Cleanup self signed certs (RDP, WinRM)
       Make sure all important files used by GCE instance setup are present.
     A valid sysprep answer file should be specified when the script is called
     or present in the source directory.
@@ -40,19 +41,6 @@
     Alias destination
   .PARAMETER help
     Print help message which is derived from the script definition.
-  .EXAMPLE
-    powershell -ExecutionPolicy Unrestricted -File sysprep.ps1
-  .EXAMPLE
-    powershell -ExecutionPolicy Unrestricted -File sysprep.ps1
-  .EXAMPLE
-    powershell -File sysprep.ps1 -unattended <file>.xml
-  .EXAMPLE
-    sysprep.ps1 -unattended unattended.xml
-  .EXAMPLE
-    powershell -ExecutionPolicy Unrestricted -File sysprep.ps1 -help
-  .NOTES
-    LastModifiedDate: $Date: 2015/06/01 $
-    Version: $Revision: #19 $
 
   #requires -version 3.0
 #>


### PR DESCRIPTION
User set min password length or local admin should not be overwritten. GCE build sets min length to 8 and disables admin user