### PR TITLE
Fall back to unauthenticated download after GCS failure

### DIFF
--- a/GCEWindowsAgent/accounts.go
+++ b/GCEWindowsAgent/accounts.go
@@ -83,17 +83,17 @@ func newPwd() (string, error) {
 		}
 
 		var l, u, n, s int
-		for _, c := range b {
-			switch {
-			case bytes.Contains(lower, []byte{c}):
-				l = 1
-			case bytes.Contains(upper, []byte{c}):
-				u = 1
-			case bytes.Contains(numbers, []byte{c}):
-				n = 1
-			case bytes.Contains(special, []byte{c}):
-				s = 1
-			}
+		if bytes.ContainsAny(lower, string(b)) {
+			l = 1
+		}
+		if bytes.ContainsAny(upper, string(b)) {
+			u = 1
+		}
+		if bytes.ContainsAny(numbers, string(b)) {
+			n = 1
+		}
+		if bytes.ContainsAny(special, string(b)) {
+			s = 1
 		}
 		// If the password does not meet Windows complexity requirements, try again.
 		// https://technet.microsoft.com/en-us/library/cc786468

--- a/GCEWindowsAgent/accounts.go
+++ b/GCEWindowsAgent/accounts.go
@@ -60,6 +60,10 @@ func (k windowsKeyJSON) expired() bool {
 	return t.Before(time.Now())
 }
 
+// newPwd will generate a random password that meets Windows complexity
+// requirements: https://technet.microsoft.com/en-us/library/cc786468.
+// Characters that are difficult for users to type on a command line (quotes,
+// non english characters) are not used.
 func newPwd() (string, error) {
 	pwLgth := 15
 	lower := []byte("abcdefghijklmnopqrstuvwxyz")

--- a/GCEWindowsAgent/accounts.go
+++ b/GCEWindowsAgent/accounts.go
@@ -72,33 +72,35 @@ func newPwd() (string, error) {
 	special := []byte(`~!@#$%^&*_-+=|\(){}[]:;<>,.?/`)
 	chars := bytes.Join([][]byte{lower, upper, numbers, special}, nil)
 
-	b := make([]byte, pwLgth)
-	for i := range b {
-		ci, err := rand.Int(rand.Reader, big.NewInt(int64(len(chars)-1)))
-		if err != nil {
-			return "", err
+	for {
+		b := make([]byte, pwLgth)
+		for i := range b {
+			ci, err := rand.Int(rand.Reader, big.NewInt(int64(len(chars))))
+			if err != nil {
+				return "", err
+			}
+			b[i] = chars[ci.Int64()]
 		}
-		b[i] = chars[ci.Int64()]
-	}
 
-	var l, u, n, s int
-	for _, c := range b {
-		switch {
-		case bytes.Contains(lower, []byte{c}):
-			l = 1
-		case bytes.Contains(upper, []byte{c}):
-			u = 1
-		case bytes.Contains(numbers, []byte{c}):
-			n = 1
-		case bytes.Contains(special, []byte{c}):
-			s = 1
+		var l, u, n, s int
+		for _, c := range b {
+			switch {
+			case bytes.Contains(lower, []byte{c}):
+				l = 1
+			case bytes.Contains(upper, []byte{c}):
+				u = 1
+			case bytes.Contains(numbers, []byte{c}):
+				n = 1
+			case bytes.Contains(special, []byte{c}):
+				s = 1
+			}
+		}
+		// If the password does not meet Windows complexity requirements, try again.
+		// https://technet.microsoft.com/en-us/library/cc786468
+		if l+u+n+s >= 3 {
+			return string(b), nil
 		}
 	}
-	// If the password does not meet Windows complexity requirements, try again.
-	if l+u+n+s >= 3 {
-		return string(b), nil
-	}
-	return newPwd()
 }
 
 func (k windowsKeyJSON) createOrResetPwd() (*credsJSON, error) {

--- a/GCEWindowsAgent/accounts_test.go
+++ b/GCEWindowsAgent/accounts_test.go
@@ -87,29 +87,29 @@ func TestAccountsDisabled(t *testing.T) {
 }
 
 func TestNewPwd(t *testing.T) {
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < 100000; i++ {
 		pwd, err := newPwd()
 		if err != nil {
 			t.Fatal(err)
 		}
 		if len(pwd) != 15 {
-			t.Fatalf("Password is not 15 characters: len(%s)=%d", pwd, len(pwd))
+			t.Errorf("Password is not 15 characters: len(%s)=%d", pwd, len(pwd))
 		}
-		var l, u, n, s bool
+		var l, u, n, s int
 		for _, r := range pwd {
 			switch {
 			case unicode.IsLower(r):
-				l = true
+				l = 1
 			case unicode.IsUpper(r):
-				u = true
+				u = 1
 			case unicode.IsDigit(r):
-				n = true
+				n = 1
 			case unicode.IsPunct(r) || unicode.IsSymbol(r):
-				s = true
+				s = 1
 			}
 		}
-		if !l || !u || !n || !s {
-			t.Fatalf("Password does not have at least one character from each category: %s", pwd)
+		if l+u+n+s < 3 {
+			t.Errorf("Password does not have at least one character from 3 categories: '%v'", pwd)
 		}
 	}
 }

--- a/google-compute-engine-metadata-scripts.goospec
+++ b/google-compute-engine-metadata-scripts.goospec
@@ -1,6 +1,6 @@
 {
   "name": "google-compute-engine-metadata-scripts",
-  "version": "4.1.1@1",
+  "version": "4.1.2@1",
   "arch": "x86_64",
   "authors": "Google Inc.",
   "license": "http://www.apache.org/licenses/LICENSE-2.0",

--- a/metadata_scripts/GCEMetadataScripts/main.go
+++ b/metadata_scripts/GCEMetadataScripts/main.go
@@ -146,7 +146,12 @@ func downloadGSURL(ctx context.Context, bucket, object string) (string, error) {
 func downloadScript(ctx context.Context, path string) (string, error) {
 	bucket, object := findMatch(path)
 	if bucket != "" && object != "" {
-		return downloadGSURL(ctx, bucket, object)
+		script, err := downloadGSURL(ctx, bucket, object)
+		if err == nil {
+			return script, nil
+		}
+		logger.Infof("Failed to download GCS path: %v", err)
+		logger.Infof("Trying unauthenticated download", err)
 	}
 
 	// Fall back to unauthenticated download of the object.


### PR DESCRIPTION
Fall back to unauthenticated download after GCS failure when pulling metadata scripts
Update password generation function to be simpler based on feedback