### PR TITLE
Add additional retry logic to script runner

### DIFF
--- a/google-compute-engine-metadata-scripts.goospec
+++ b/google-compute-engine-metadata-scripts.goospec
@@ -1,6 +1,6 @@
 {
   "name": "google-compute-engine-metadata-scripts",
-  "version": "4.1.5@1",
+  "version": "4.1.6@1",
   "arch": "x86_64",
   "authors": "Google Inc.",
   "license": "http://www.apache.org/licenses/LICENSE-2.0",
@@ -15,6 +15,7 @@
     "path": "metadata_scripts_uninstall.ps1"
   },
   "releaseNotes": [
+    "4.1.6 - Add additional retry logic to account for slow network startup and transient GCS errors.",
     "4.1.3 - Add a sleep in case DNS is not started at boot.",
     "4.1.0 - Add startup and shutdown settings.",
     "4.0.0 - Rewrite GCEMetadataScripts in Go.",

--- a/metadata_scripts/GCEMetadataScripts/main_test.go
+++ b/metadata_scripts/GCEMetadataScripts/main_test.go
@@ -121,7 +121,7 @@ func TestGetMetadata(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	metadataServer = ts.URL
+	metadataURL = ts.URL
 	metadataHang = ""
 
 	want := map[string]string{"key1": "value1", "key2": "value2"}


### PR DESCRIPTION
Retries to account for slow network startup and transient GCS errors.