### PR TITLE
Use *UnicastIpAddressEntry functions for managing forwarded IPs

### DIFF
--- a/GCEWindowsAgent/addresses.go
+++ b/GCEWindowsAgent/addresses.go
@@ -15,12 +15,11 @@
 package main
 
 import (
+	"fmt"
 	"net"
 	"reflect"
 	"strconv"
 	"strings"
-
-	"fmt"
 
 	"github.com/GoogleCloudPlatform/compute-image-windows/logger"
 	"github.com/go-ini/ini"

--- a/GCEWindowsAgent/main.go
+++ b/GCEWindowsAgent/main.go
@@ -128,6 +128,11 @@ func run(ctx context.Context) {
 				time.Sleep(5 * time.Second)
 				continue
 			}
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
 			runUpdate(newMetadata, &oldMetadata)
 			oldMetadata = *newMetadata
 			printWebException = true

--- a/GCEWindowsAgent/main.go
+++ b/GCEWindowsAgent/main.go
@@ -17,11 +17,10 @@ package main
 
 import (
 	"context"
+	"io/ioutil"
 	"os"
 	"sync"
 	"time"
-
-	"io/ioutil"
 
 	"github.com/GoogleCloudPlatform/compute-image-windows/logger"
 	"github.com/go-ini/ini"

--- a/GCEWindowsAgent/stub_linux.go
+++ b/GCEWindowsAgent/stub_linux.go
@@ -37,11 +37,11 @@ func writeRegMultiString(key, name string, value []string) error {
 	return nil
 }
 
-func addIPAddress(ip, mask net.IP, index int) error {
+func addAddress(ip, mask net.IP, index uint32) error {
 	return nil
 }
 
-func deleteIPAddress(ip net.IP) error {
+func removeAddress(ip net.IP, index uint32) error {
 	return nil
 }
 


### PR DESCRIPTION
Use SkipAsSource flag for all forwarded IPs 
Clean up messages about forwarded IPs
Fix WSFC manager to not panic on service stop