### PR TITLE
accounts: load serial port from config file

### DIFF
--- a/GCEWindowsAgent/accounts.go
+++ b/GCEWindowsAgent/accounts.go
@@ -194,12 +194,20 @@ type credsJSON struct {
 	Modulus           string `json:"modulus,omitempty"`
 }
 
-func printCreds(creds *credsJSON) error {
+func (a *accounts) parseSerialPort() string {
+	port := a.config.Section("accountManager").Key("serialPort").String()
+	if len(port) > 0 {
+		return port
+	}
+	return "COM4"
+}
+
+func (a *accounts) printCreds(creds *credsJSON) error {
 	data, err := json.Marshal(creds)
 	if err != nil {
 		return err
 	}
-	return writeSerial("COM4", append(data, []byte("\n")...))
+	return writeSerial(a.parseSerialPort(), append(data, []byte("\n")...))
 }
 
 var badReg []string
@@ -269,7 +277,7 @@ func (a *accounts) set() error {
 	for _, key := range toAdd {
 		creds, err := key.createOrResetPwd()
 		if err == nil {
-			printCreds(creds)
+			a.printCreds(creds)
 			continue
 		}
 		logger.Error(err)
@@ -280,7 +288,7 @@ func (a *accounts) set() error {
 			UserName:      key.UserName,
 			ErrorMessage:  err.Error(),
 		}
-		printCreds(creds)
+		a.printCreds(creds)
 	}
 
 	var jsonKeys []string

--- a/GCEWindowsAgent/accounts_test.go
+++ b/GCEWindowsAgent/accounts_test.go
@@ -86,6 +86,33 @@ func TestAccountsDisabled(t *testing.T) {
 	}
 }
 
+func TestAccountsSerialPort(t *testing.T) {
+	var tests = []struct {
+		name string
+		data []byte
+		md   *metadataJSON
+		want string
+	}{
+		{"default serial port", []byte(""), &metadataJSON{}, "COM4"},
+		{"set serial port", []byte("[accountManager]\nserialPort=COM2"), &metadataJSON{}, "COM2"},
+	}
+
+	for _, tt := range tests {
+		cfg, err := ini.InsensitiveLoad(tt.data)
+		if err != nil {
+			t.Errorf("test case %q: error parsing config: %v", tt.name, err)
+			continue
+		}
+		if cfg == nil {
+			cfg = &ini.File{}
+		}
+		got := (&accounts{newMetadata: tt.md, config: cfg}).parseSerialPort()
+		if got != tt.want {
+			t.Errorf("test case %q, accounts.parseSerialPort() got: %q, want: %q", tt.name, got, tt.want)
+		}
+	}
+}
+
 func TestNewPwd(t *testing.T) {
 	for i := 0; i < 100000; i++ {
 		pwd, err := newPwd()

--- a/google-compute-engine-windows.goospec
+++ b/google-compute-engine-windows.goospec
@@ -1,6 +1,6 @@
 {
   "name": "google-compute-engine-windows",
-  "version": "4.2.2@2",
+  "version": "4.2.3@1",
   "arch": "x86_64",
   "authors": "Google Inc.",
   "license": "http://www.apache.org/licenses/LICENSE-2.0",
@@ -15,6 +15,7 @@
     "path": "agent_uninstall.ps1"
   },
   "releaseNotes": [
+    "4.2.3 - Add Serial Port configuration parameter",
     "4.2.0 - Use *UnicastIpAddressEntry functions for managing forwarded IPs",
     "4.1.0 - Add configuration file",
     "4.0.0 - Rewrite GCEAgent in Go",


### PR DESCRIPTION
This PR adds the serialPort on the accountManager config section.

Config example:
```ìni
# GCE Instance Configuration

[accountManager]
# disable=false
serialPort=COM2
```
