### PR TITLE
Cleanup sysprep scripts

### DIFF
--- a/google-compute-engine-sysprep.goospec
+++ b/google-compute-engine-sysprep.goospec
@@ -1,6 +1,6 @@
 {
   "name": "google-compute-engine-sysprep",
-  "version": "3.6.7@1",
+  "version": "3.6.8@1",
   "arch": "noarch",
   "authors": "Google Inc.",
   "license": "http://www.apache.org/licenses/LICENSE-2.0",

--- a/sysprep/activate_instance.ps1
+++ b/sysprep/activate_instance.ps1
@@ -206,7 +206,7 @@ function Verify-ActivationStatus {
     return $active
   }
 
-  $status = $slmgr_status.Split("`n") | Select-String -Pattern '^License Status:'
+  $status = $slmgr_status | Select-String -Pattern '^License Status:'
   if ($status -match 'Licensed') {
     $active = $true
   }

--- a/sysprep/instance_setup.ps1
+++ b/sysprep/instance_setup.ps1
@@ -21,9 +21,10 @@
     Some of the task performed by the scripts are:
       Change the hostname to match the GCE hostname
       Activate the GCE instance
-
-  #requires -version 3.0
 #>
+
+#requires -version 3.0
+
 [CmdletBinding()]
 param (
   [Parameter(HelpMessage = 'Sysprep specialize phase.')]
@@ -66,8 +67,10 @@ function Change-InstanceName {
   Write-Log 'Getting hostname from metadata server.'
 
   if ((Get-CimInstance Win32_BIOS).Manufacturer -cne 'Google') {
-    Write-Log 'Not running in a Google Compute Engine VM.' -error
-    return
+    if (-not (Test-Connection -Count 1 metadata.google.internal -ErrorAction SilentlyContinue)) {
+      Write-Log 'Not running in a Google Compute Engine VM.' -error
+      return
+    }
   }
 
   $count = 1

--- a/sysprep/instance_setup.ps1
+++ b/sysprep/instance_setup.ps1
@@ -113,7 +113,6 @@ function Change-InstanceProperties {
   # Set all Adapters to get IP from DHCP.
   $nics = Get-CimInstance Win32_NetworkAdapterConfiguration -Filter "IPEnabled=True"
   $nics | Invoke-CimMethod -Name EnableDHCP
-  $nics | Invoke-CimMethod -Name EnableDHCP
 
   $netkvm = Get-CimInstance Win32_NetworkAdapter -filter "ServiceName='netkvm'"
   $netkvm | ForEach-Object {


### PR DESCRIPTION
Don't require PowerShell 3 or the gce_base module import for activation.
Use the presence of the metadata server as a signal we are in fact running in GCE.