### PR TITLE
Clean up errors in Windows agent

### DIFF
--- a/GCEWindowsAgent/main.go
+++ b/GCEWindowsAgent/main.go
@@ -76,11 +76,11 @@ func parseConfig(file string) (*ini.File, error) {
 
 func runUpdate(newMetadata, oldMetadata *metadataJSON) {
 	cfg, err := parseConfig(configPath)
-	if err != nil && err != os.ErrNotExist {
+	if err != nil && !os.IsNotExist(err) {
 		logger.Error(err)
 	}
 	if cfg == nil {
-		cfg = &ini.File{}
+		cfg, _ = ini.InsensitiveLoad([]byte{})
 	}
 
 	var wg sync.WaitGroup

--- a/GCEWindowsAgent/main.go
+++ b/GCEWindowsAgent/main.go
@@ -122,8 +122,8 @@ func run(ctx context.Context) {
 		for {
 			newMetadata, err := watchMetadata(ctx)
 			if err != nil {
-				// Only log the second web error to avoid transient erros and
-				// not to spam on connection failures.
+				// Only log the second web error to avoid transient errors and
+				// not to spam the log on network failures.
 				if webError == 1 {
 					if urlErr, ok := err.(*url.Error); ok {
 						if _, ok := urlErr.Err.(*net.DNSError); ok {

--- a/google-compute-engine-windows.goospec
+++ b/google-compute-engine-windows.goospec
@@ -1,6 +1,6 @@
 {
   "name": "google-compute-engine-windows",
-  "version": "4.2.2@2",
+  "version": "4.2.3@2",
   "arch": "x86_64",
   "authors": "Google Inc.",
   "license": "http://www.apache.org/licenses/LICENSE-2.0",
@@ -15,6 +15,8 @@
     "path": "agent_uninstall.ps1"
   },
   "releaseNotes": [
+    "4.2.3 - Don't error on lack of config file, only run update on updated metadata",
+    "      - Make DNS and Network errors more user friendly",
     "4.2.0 - Use *UnicastIpAddressEntry functions for managing forwarded IPs",
     "4.1.0 - Add configuration file",
     "4.0.0 - Rewrite GCEAgent in Go",

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -18,12 +18,11 @@ package logger
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
 	"runtime"
-
-	"io"
 
 	"github.com/tarm/serial"
 )


### PR DESCRIPTION
Make DNS and Network errors more user friendly
Only run update on updated metadata
Don't error on lack of config file