### PR TITLE
Add metadata listener for diagnostics tool.

### DIFF
--- a/GCEWindowsAgent/diagnostics.go
+++ b/GCEWindowsAgent/diagnostics.go
@@ -1,0 +1,122 @@
+//  Copyright 2018 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"os/exec"
+	"reflect"
+	"strconv"
+	"time"
+
+	"github.com/GoogleCloudPlatform/compute-image-windows/logger"
+	"github.com/go-ini/ini"
+)
+
+const diagnosticsCmd = `C:\Program Files\Google\Compute Engine\diagnostics\diagnostics.exe`
+
+var (
+	diagnosticsDisabled = false
+)
+
+type diagnosticsKeyJSON struct {
+	SignedUrl string
+	ExpireOn  string
+	TraceFlag bool
+}
+
+func (k diagnosticsKeyJSON) expired() bool {
+	t, err := time.Parse(time.RFC3339, k.ExpireOn)
+	if err != nil {
+		if !containsString(k.ExpireOn, badExpire) {
+			logger.Errorln("Error parsing time:", err)
+			badExpire = append(badExpire, k.ExpireOn)
+		}
+		return true
+	}
+	return t.Before(time.Now())
+}
+
+type diagnostics struct {
+	newMetadata, oldMetadata *metadataJSON
+	config                   *ini.File
+}
+
+func (a *diagnostics) diff() bool {
+	return !reflect.DeepEqual(a.newMetadata.Instance.Attributes.DiagnosticsKeys, a.oldMetadata.Instance.Attributes.DiagnosticsKeys)
+}
+
+func (a *diagnostics) disabled() (disabled bool) {
+	defer func() {
+		if disabled != diagnosticsDisabled {
+			diagnosticsDisabled = disabled
+			logStatus("diagnostics", disabled)
+		}
+	}()
+
+	var err error
+	disabled, err = strconv.ParseBool(a.config.Section("diagnostics").Key("disable").String())
+	if err == nil {
+		return disabled
+	}
+	disabled, err = strconv.ParseBool(a.newMetadata.Instance.Attributes.DisableDiagnostics)
+	if err == nil {
+		return disabled
+	}
+	disabled, err = strconv.ParseBool(a.newMetadata.Project.Attributes.DisableDiagnostics)
+	if err == nil {
+		return disabled
+	}
+	return diagnosticsDisabled
+}
+
+var diagnosticsKeys []string
+
+func (a *diagnostics) set() error {
+	var key diagnosticsKeyJSON
+	strKey := a.newMetadata.Instance.Attributes.DiagnosticsKeys
+	if containsString(strKey, diagnosticsKeys) {
+		return nil
+	}
+
+	diagnosticsKeys = append(diagnosticsKeys, strKey)
+	if err := json.Unmarshal([]byte(strKey), &key); err != nil {
+		logger.Error(err)
+		return nil
+	}
+	if key.SignedUrl == "" || key.expired() {
+		return nil
+	}
+
+	args := []string{
+		"-signedUrl",
+		key.SignedUrl,
+	}
+	if key.TraceFlag {
+		args = append(args, "-trace")
+	}
+
+	cmd := exec.Command(diagnosticsCmd, args...)
+	go func() {
+		logger.Info("Collecting logs from the system:")
+		out, err := cmd.CombinedOutput()
+		logger.Info(string(out[:]))
+		if err != nil {
+			logger.Infof("Error collecting logs: %v", err)
+		}
+	}()
+
+	return nil
+}

--- a/GCEWindowsAgent/diagnostics_test.go
+++ b/GCEWindowsAgent/diagnostics_test.go
@@ -1,0 +1,75 @@
+//  Copyright 2018 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-ini/ini"
+)
+
+func TestDiagnosticsEntryExpired(t *testing.T) {
+	var tests = []struct {
+		sTime string
+		e     bool
+	}{
+		{time.Now().Add(5 * time.Minute).Format(time.RFC3339), false},
+		{time.Now().Add(-5 * time.Minute).Format(time.RFC3339), true},
+		{"some bad time", true},
+	}
+
+	for _, tt := range tests {
+		k := diagnosticsEntryJSON{ExpireOn: tt.sTime}
+		if tt.e != k.expired() {
+			t.Errorf("diagnosticsEntryJSON.expired() with ExpiredOn %q should return %t", k.ExpireOn, tt.e)
+		}
+	}
+}
+
+func TestDiagnosticsDisabled(t *testing.T) {
+	var tests = []struct {
+		name string
+		data []byte
+		md   *metadataJSON
+		want bool
+	}{
+		{"not explicitly enabled", []byte(""), &metadataJSON{}, true},
+		{"enabled in cfg only", []byte("[diagnostics]\nenable=true"), &metadataJSON{}, false},
+		{"disabled in cfg only", []byte("[diagnostics]\nenable=false"), &metadataJSON{}, true},
+		{"disabled in cfg, enabled in instance metadata", []byte("[diagnostics]\nenable=false"), &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{EnableDiagnostics: "true"}}}, true},
+		{"enabled in cfg, disabled in instance metadata", []byte("[diagnostics]\nenable=true"), &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{EnableDiagnostics: "false"}}}, false},
+		{"enabled in instance metadata only", []byte(""), &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{EnableDiagnostics: "true"}}}, false},
+		{"enabled in project metadata only", []byte(""), &metadataJSON{Project: projectJSON{Attributes: attributesJSON{EnableDiagnostics: "true"}}}, false},
+		{"disabled in instance metadata only", []byte(""), &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{EnableDiagnostics: "false"}}}, true},
+		{"enabled in instance metadata, disabled in project metadata", []byte(""), &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{EnableDiagnostics: "true"}}, Project: projectJSON{Attributes: attributesJSON{EnableDiagnostics: "false"}}}, false},
+		{"disabled in project metadata only", []byte(""), &metadataJSON{Project: projectJSON{Attributes: attributesJSON{EnableDiagnostics: "false"}}}, true},
+	}
+
+	for _, tt := range tests {
+		cfg, err := ini.InsensitiveLoad(tt.data)
+		if err != nil {
+			t.Errorf("test case %q: error parsing config: %v", tt.name, err)
+			continue
+		}
+		if cfg == nil {
+			cfg = &ini.File{}
+		}
+		got := (&diagnostics{newMetadata: tt.md, config: cfg}).disabled()
+		if got != tt.want {
+			t.Errorf("test case %q, diagnostics.disabled() got: %t, want: %t", tt.name, got, tt.want)
+		}
+	}
+}

--- a/GCEWindowsAgent/main.go
+++ b/GCEWindowsAgent/main.go
@@ -96,9 +96,14 @@ func runUpdate(newMetadata, oldMetadata *metadataJSON) {
 		newMetadata: newMetadata,
 		config:      cfg,
 	}
+	diagMgr := &diagnostics{
+		oldMetadata: oldMetadata,
+		newMetadata: newMetadata,
+		config:      cfg,
+	}
 	wsfcMgr := newWsfcManager(newMetadata, cfg)
 
-	for _, mgr := range []manager{addressMgr, acctMgr, wsfcMgr} {
+	for _, mgr := range []manager{addressMgr, acctMgr, wsfcMgr, diagMgr} {
 		wg.Add(1)
 		go func(mgr manager) {
 			defer wg.Done()

--- a/GCEWindowsAgent/metadata.go
+++ b/GCEWindowsAgent/metadata.go
@@ -52,8 +52,10 @@ type projectJSON struct {
 
 type attributesJSON struct {
 	WindowsKeys           string `json:"windows-keys"`
+	DiagnosticsKeys       string `json:"diagnostics"`
 	DisableAddressManager string `json:"disable-address-manager"`
 	DisableAccountManager string `json:"disable-account-manager"`
+	DisableDiagnostics    string `json:"disable-diagnostics"`
 	EnableWSFC            string `json:"enable-wsfc"`
 	WSFCAddresses         string `json:"wsfc-addrs"`
 	WSFCAgentPort         string `json:"wsfc-agent-port"`

--- a/GCEWindowsAgent/metadata.go
+++ b/GCEWindowsAgent/metadata.go
@@ -52,10 +52,10 @@ type projectJSON struct {
 
 type attributesJSON struct {
 	WindowsKeys           string `json:"windows-keys"`
-	DiagnosticsKeys       string `json:"diagnostics"`
+	Diagnostics           string `json:"diagnostics"`
 	DisableAddressManager string `json:"disable-address-manager"`
 	DisableAccountManager string `json:"disable-account-manager"`
-	DisableDiagnostics    string `json:"disable-diagnostics"`
+	EnableDiagnostics     string `json:"enable-diagnostics"`
 	EnableWSFC            string `json:"enable-wsfc"`
 	WSFCAddresses         string `json:"wsfc-addrs"`
 	WSFCAgentPort         string `json:"wsfc-agent-port"`

--- a/google-compute-engine-windows.goospec
+++ b/google-compute-engine-windows.goospec
@@ -1,6 +1,6 @@
 {
   "name": "google-compute-engine-windows",
-  "version": "4.2.3@2",
+  "version": "4.3.0@1",
   "arch": "x86_64",
   "authors": "Google Inc.",
   "license": "http://www.apache.org/licenses/LICENSE-2.0",
@@ -15,6 +15,7 @@
     "path": "agent_uninstall.ps1"
   },
   "releaseNotes": [
+    "4.3.0 - Add diagnostics support for optional log extraction",
     "4.2.3 - Don't error on lack of config file, only run update on updated metadata",
     "      - Make DNS and Network errors more user friendly",
     "4.2.0 - Use *UnicastIpAddressEntry functions for managing forwarded IPs",


### PR DESCRIPTION
Calls executable to extract logs when triggered from the Metadata Server.