### PR TITLE
Allow project level startup and shutdown scripts.

### DIFF
--- a/metadata_scripts/GCEMetadataScripts/main_test.go
+++ b/metadata_scripts/GCEMetadataScripts/main_test.go
@@ -125,7 +125,7 @@ func TestGetMetadata(t *testing.T) {
 	metadataHang = ""
 
 	want := map[string]string{"key1": "value1", "key2": "value2"}
-	got, err := getMetadata()
+	got, err := getMetadata("/instance/attributes")
 	if err != nil {
 		t.Fatalf("error running getMetadata: %v", err)
 	}


### PR DESCRIPTION
Use project level scripts when there are no scripts specified at the
instance level in metadata.