### PR TITLE
GCEWindowsAgent: run update on every metadata return

### DIFF
--- a/GCEWindowsAgent/accounts_test.go
+++ b/GCEWindowsAgent/accounts_test.go
@@ -15,19 +15,18 @@
 package main
 
 import (
+	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha1"
 	"encoding/base64"
+	"fmt"
 	"log"
 	"math/big"
 	"reflect"
 	"testing"
 	"time"
 	"unicode"
-
-	"bytes"
-	"fmt"
 
 	"github.com/GoogleCloudPlatform/compute-image-windows/logger"
 	"github.com/go-ini/ini"
@@ -79,7 +78,9 @@ func TestAccountsDisabled(t *testing.T) {
 		if cfg == nil {
 			cfg = &ini.File{}
 		}
-		got := (&accounts{newMetadata: tt.md, config: cfg}).disabled()
+		newMetadata = tt.md
+		config = cfg
+		got := (&accountsMgr{}).disabled()
 		if got != tt.want {
 			t.Errorf("test case %q, accounts.disabled() got: %t, want: %t", tt.name, got, tt.want)
 		}
@@ -185,7 +186,10 @@ func TestAccountsLogStatus(t *testing.T) {
 
 	// Disable it.
 	accountDisabled = false
-	disabled := (&accounts{newMetadata: &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{DisableAccountManager: "true"}}}, config: ini.Empty()}).disabled()
+
+	newMetadata = &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{DisableAccountManager: "true"}}}
+	config = ini.Empty()
+	disabled := (&accountsMgr{}).disabled()
 	if !disabled {
 		t.Fatal("expected true but got", disabled)
 	}
@@ -196,7 +200,8 @@ func TestAccountsLogStatus(t *testing.T) {
 	buf.Reset()
 
 	// Enable it.
-	disabled = (&accounts{newMetadata: &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{DisableAccountManager: "false"}}}, config: ini.Empty()}).disabled()
+	newMetadata = &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{DisableAccountManager: "false"}}}
+	disabled = (&accountsMgr{}).disabled()
 	if disabled {
 		t.Fatal("expected false but got", disabled)
 	}

--- a/GCEWindowsAgent/diagnostics_test.go
+++ b/GCEWindowsAgent/diagnostics_test.go
@@ -67,7 +67,9 @@ func TestDiagnosticsDisabled(t *testing.T) {
 		if cfg == nil {
 			cfg = &ini.File{}
 		}
-		got := (&diagnostics{newMetadata: tt.md, config: cfg}).disabled()
+		newMetadata = tt.md
+		config = cfg
+		got := (&diagnosticsMgr{}).disabled()
 		if got != tt.want {
 			t.Errorf("test case %q, diagnostics.disabled() got: %t, want: %t", tt.name, got, tt.want)
 		}

--- a/GCEWindowsAgent/main_test.go
+++ b/GCEWindowsAgent/main_test.go
@@ -14,7 +14,45 @@
 
 package main
 
-import "testing"
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/compute-image-windows/logger"
+)
+
+func TestRunUpdate(t *testing.T) {
+	logger.Init("TestRunUpdate", "")
+	var buf bytes.Buffer
+	logger.Log = log.New(&buf, "", 0)
+
+	oldMetadata = &metadataJSON{}
+	newMetadata = &metadataJSON{
+		Instance: instanceJSON{
+			Attributes: attributesJSON{
+				WindowsKeys:           "{}",
+				Diagnostics:           "{}",
+				DisableAddressManager: "false",
+				DisableAccountManager: "false",
+				EnableDiagnostics:     "true",
+				EnableWSFC:            "true",
+				WSFCAddresses:         "1.1.1.1",
+				WSFCAgentPort:         "8000",
+			},
+		},
+	}
+	// This test is a bit simplistic, but should catch any unexpected errors or
+	// race conditions.
+	runUpdate()
+
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if strings.Contains(line, "ERROR") {
+			t.Errorf("error in runUpdate(): %s", line)
+		}
+	}
+}
 
 func TestContainsString(t *testing.T) {
 	table := []struct {

--- a/GCEWindowsAgent/metadata_test.go
+++ b/GCEWindowsAgent/metadata_test.go
@@ -1,0 +1,59 @@
+//  Copyright 2018 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestWatchMetadata(t *testing.T) {
+	etag1, etag2 := "foo", "bar"
+	var req int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if req == 0 {
+			w.Header().Set("etag", etag1)
+		} else {
+			w.Header().Set("etag", etag2)
+		}
+		fmt.Fprintln(w, `{"project":{"attributes":{"windows-keys":"foo"}}}`)
+		req++
+	}))
+	defer ts.Close()
+
+	metadataURL = ts.URL
+	// So that the test wont timeout.
+	defaultTimeout = 1 * time.Second
+
+	want := "foo"
+	for _, e := range []string{etag1, etag2} {
+		got, err := watchMetadata(context.Background())
+		if err != nil {
+			t.Fatalf("error running getMetadata: %v", err)
+		}
+
+		if got.Project.Attributes.WindowsKeys != want {
+			t.Errorf("%q != %q", got.Project.Attributes.WindowsKeys, want)
+		}
+
+		if etag != e {
+			t.Errorf("etag not updated as expected (%q != %q)", etag, e)
+		}
+	}
+}

--- a/GCEWindowsAgent/wsfc.go
+++ b/GCEWindowsAgent/wsfc.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/compute-image-windows/logger"
-	"github.com/go-ini/ini"
 )
 
 const wsfcDefaultAgentPort = "59998"
@@ -50,7 +49,7 @@ type wsfcManager struct {
 // running if one of the following is true:
 // - EnableWSFC is set
 // - WSFCAddresses is set (As an advanced setting, it will always override EnableWSFC flag)
-func newWsfcManager(newMetadata *metadataJSON, config *ini.File) *wsfcManager {
+func newWsfcManager() *wsfcManager {
 	newState := stopped
 
 	enabled, err := config.Section("wsfc").Key("enabled").Bool()
@@ -90,6 +89,10 @@ func (m *wsfcManager) diff() bool {
 // wsfc manager is always enabled. The manager is just a broker which manages the state of wsfcAgent. User
 // can disable the wsfc feature by setting the metadata. If the manager is disabled, the agent will stop.
 func (m *wsfcManager) disabled() bool {
+	return false
+}
+
+func (m *wsfcManager) timeout() bool {
 	return false
 }
 

--- a/GCEWindowsAgent/wsfc_test.go
+++ b/GCEWindowsAgent/wsfc_test.go
@@ -60,8 +60,10 @@ func TestNewWsfcManager(t *testing.T) {
 		{"wsfc addrs is set", args{setWSFCAddresses(testMetadata, "0.0.0.0")}, &wsfcManager{agentNewState: running, agentNewPort: wsfcDefaultAgentPort, agent: testAgent}},
 		{"wsfc port is set", args{setWSFCAgentPort(testMetadata, "1818")}, &wsfcManager{agentNewState: stopped, agentNewPort: "1818", agent: testAgent}},
 	}
+	config = ini.Empty()
 	for _, tt := range tests {
-		if got := newWsfcManager(tt.args.newMetadata, ini.Empty()); !reflect.DeepEqual(got, tt.want) {
+		newMetadata = tt.args.newMetadata
+		if got := newWsfcManager(); !reflect.DeepEqual(got, tt.want) {
 			t.Errorf("test case %q: newWsfcManager() = %v, want %v", tt.name, got, tt.want)
 		}
 	}

--- a/google-compute-engine-windows.goospec
+++ b/google-compute-engine-windows.goospec
@@ -1,6 +1,6 @@
 {
   "name": "google-compute-engine-windows",
-  "version": "4.3.0@1",
+  "version": "4.4.0@1",
   "arch": "x86_64",
   "authors": "Google Inc.",
   "license": "http://www.apache.org/licenses/LICENSE-2.0",
@@ -15,6 +15,8 @@
     "path": "agent_uninstall.ps1"
   },
   "releaseNotes": [
+    "4.4.0 - Run updates on every metadata return, including timeout"
+           - Add individual manager timeout to address manager",
     "4.3.0 - Add diagnostics support for optional log extraction",
     "4.2.3 - Don't error on lack of config file, only run update on updated metadata",
     "      - Make DNS and Network errors more user friendly",


### PR DESCRIPTION
Don't check etag on metadata return, run update regardless. Most managers will simply return false on diff() and set() will not run.
Add individual manager timeout function, currently only set for address manager. This will run set() if time since last cycle has exceeded timeout.
Make oldMetadata, newMetadata variables global as they were used this way anyway. This simplifies logic a bit.
Add tests for metadata.
Add test for runUpdate to check for any race conditions.