### PR TITLE
GCEWindowsAgent: only compare limited set of fields in old keys

### DIFF
--- a/GCEWindowsAgent/accounts.go
+++ b/GCEWindowsAgent/accounts.go
@@ -250,9 +250,9 @@ func compareAccounts(newKeys []windowsKeyJSON, oldStrKeys []string) []windowsKey
 	for _, key := range newKeys {
 		if func(key windowsKeyJSON, oldKeys []windowsKeyJSON) bool {
 			for _, oldKey := range oldKeys {
-				if oldKey.Email == key.Email &&
-					oldKey.Exponent == key.Modulus &&
-					oldKey.Modulus == key.ExpireOn {
+				if oldKey.UserName == key.UserName &&
+					oldKey.Modulus == key.Modulus &&
+					oldKey.ExpireOn == key.ExpireOn {
 					return false
 				}
 			}

--- a/GCEWindowsAgent/accounts.go
+++ b/GCEWindowsAgent/accounts.go
@@ -250,7 +250,9 @@ func compareAccounts(newKeys []windowsKeyJSON, oldStrKeys []string) []windowsKey
 	for _, key := range newKeys {
 		if func(key windowsKeyJSON, oldKeys []windowsKeyJSON) bool {
 			for _, oldKey := range oldKeys {
-				if reflect.DeepEqual(oldKey, key) {
+				if oldKey.Email == key.Email &&
+					oldKey.Exponent == key.Modulus &&
+					oldKey.Modulus == key.ExpireOn {
 					return false
 				}
 			}

--- a/GCEWindowsAgent/accounts_test.go
+++ b/GCEWindowsAgent/accounts_test.go
@@ -176,9 +176,9 @@ func TestCompareAccounts(t *testing.T) {
 		{[]windowsKeyJSON{{UserName: "foo"}}, []string{`{"UserName":"bar"}`}, []windowsKeyJSON{{UserName: "foo"}}},
 
 		// These should return nothing:
-		// In Reg and Md
+		// In Reg and MD
 		{[]windowsKeyJSON{{UserName: "foo"}}, []string{`{"UserName":"foo"}`}, nil},
-		// In Md, not Reg
+		// In Reg, not MD
 		{nil, []string{`{UserName":"foo"}`}, nil},
 	}
 

--- a/google-compute-engine-windows.goospec
+++ b/google-compute-engine-windows.goospec
@@ -1,6 +1,6 @@
 {
   "name": "google-compute-engine-windows",
-  "version": "4.5.2@2",
+  "version": "4.5.3@1",
   "arch": "x86_64",
   "authors": "Google Inc.",
   "license": "http://www.apache.org/licenses/LICENSE-2.0",

--- a/google-compute-engine-windows.goospec
+++ b/google-compute-engine-windows.goospec
@@ -1,6 +1,6 @@
 {
   "name": "google-compute-engine-windows",
-  "version": "4.5.2@1",
+  "version": "4.5.2@2",
   "arch": "x86_64",
   "authors": "Google Inc.",
   "license": "http://www.apache.org/licenses/LICENSE-2.0",


### PR DESCRIPTION
Adding new fields (like HashFunction) could cause passwords to get reset again on agent upgrade.