### PR TITLE
Allow building where GOOS is not Windows or Linux

### DIFF
--- a/GCEWindowsAgent/stub.go
+++ b/GCEWindowsAgent/stub.go
@@ -12,6 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+// +build !windows
+
 package main
 
 import (

--- a/agent_build.sh
+++ b/agent_build.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-version=$(cat google-compute-engine-windows.goospec | grep -Po '"version":\s+"\K.+(?=",)')
+version=$(cat google-compute-engine-windows.goospec | sed -nE 's/.*"version":.*"(.+)".*/\1/p')
 if [[ $? -ne 0 ]]; then
   echo "could not match version in goospec"
   exit 1

--- a/logger/stub.go
+++ b/logger/stub.go
@@ -12,6 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+// +build !windows
+
 package logger
 
 import (
@@ -20,7 +22,7 @@ import (
 )
 
 func slSetup(src string) error {
-	// Linux stub for running tests.
+	// Stub for running tests.
 	slInfo = log.New(ioutil.Discard, "", 0)
 	slError = slInfo
 	slFatal = slInfo


### PR DESCRIPTION
These changes make the stub files no longer be linux specific. It also
changes agent_build.sh to no longer use GNU grep specific extensions.