### PR TITLE
Always print "Finished..." at the end of metadata scripts

### DIFF
--- a/google-compute-engine-metadata-scripts.goospec
+++ b/google-compute-engine-metadata-scripts.goospec
@@ -1,6 +1,6 @@
 {
   "name": "google-compute-engine-metadata-scripts",
-  "version": "4.2.0@1",
+  "version": "4.2.1@1",
   "arch": "x86_64",
   "authors": "Google Inc.",
   "license": "http://www.apache.org/licenses/LICENSE-2.0",

--- a/metadata_scripts/GCEMetadataScripts/main.go
+++ b/metadata_scripts/GCEMetadataScripts/main.go
@@ -414,10 +414,9 @@ func main() {
 
 	if len(scripts) == 0 {
 		logger.Infof("No %s scripts to run.", os.Args[1])
-		os.Exit(0)
+	} else {
+		ctx := context.Background()
+		runScripts(ctx, scripts)
 	}
-
-	ctx := context.Background()
-	runScripts(ctx, scripts)
 	logger.Infof("Finished running %s scripts.", os.Args[1])
 }


### PR DESCRIPTION
Change motivated to make it match Linux's agent behavior

Reference: https://github.com/GoogleCloudPlatform/compute-image-packages/blob/master/google_compute_engine/metadata_scripts/script_manager.py#L82