### PR TITLE
Set GCEStartup task to Normal process priority

### DIFF
--- a/sysprep/instance_setup.ps1
+++ b/sysprep/instance_setup.ps1
@@ -237,6 +237,7 @@ function Create-GCEStartup {
   $task = $service.NewTask(0)
   $task.Settings.Enabled = $true
   $task.Settings.AllowDemandStart = $true
+  $task.Settings.Priority = 5
   $action = $task.Actions.Create(0)
   $action.Path = "`"$run_startup_scripts`""
   $trigger = $task.Triggers.Create(8)


### PR DESCRIPTION
Set GCEStartup task process and child processes to Normal process priority

Default process priority for scheduled tasks is "Below Normal" which can cause the GCEStartup task to hang. Setting the GCEStartup task to priority 5 (rather than default priority 7) on task creation ensures that the process it spawns, and any child processes, run with Normal process priority.