### PR TITLE
metadata scripts: use the tasks API for this create call in the package

### DIFF
--- a/google-compute-engine-metadata-scripts.goospec
+++ b/google-compute-engine-metadata-scripts.goospec
@@ -1,6 +1,6 @@
 {
   "name": "google-compute-engine-metadata-scripts",
-  "version": "4.2.1@1",
+  "version": "4.2.1@2",
   "arch": "x86_64",
   "authors": "Google Inc.",
   "license": "http://www.apache.org/licenses/LICENSE-2.0",


### PR DESCRIPTION
We have to use the API for this create call as schtasks.exe sets an activation time of now for a task with the onstart schedule, this causes issues when the timezone is changed.