### PR TITLE
Custom unmarshaller for attributes

### DIFF
--- a/GCEWindowsAgent/addresses.go
+++ b/GCEWindowsAgent/addresses.go
@@ -53,13 +53,11 @@ func (a *addressMgr) parseWSFCEnable() bool {
 	if err == nil {
 		return wsfcEnable
 	}
-	wsfcEnable, err = strconv.ParseBool(newMetadata.Instance.Attributes.EnableWSFC)
-	if err == nil {
-		return wsfcEnable
+	if newMetadata.Instance.Attributes.EnableWSFC != nil {
+		return *newMetadata.Instance.Attributes.EnableWSFC
 	}
-	wsfcEnable, err = strconv.ParseBool(newMetadata.Project.Attributes.EnableWSFC)
-	if err == nil {
-		return wsfcEnable
+	if newMetadata.Project.Attributes.EnableWSFC != nil {
+		return *newMetadata.Project.Attributes.EnableWSFC
 	}
 	return false
 }
@@ -99,12 +97,12 @@ func (a *addressMgr) disabled() (disabled bool) {
 	if err == nil {
 		return disabled
 	}
-	disabled, err = strconv.ParseBool(newMetadata.Instance.Attributes.DisableAddressManager)
-	if err == nil {
+	if newMetadata.Instance.Attributes.DisableAddressManager != nil {
+		disabled = *newMetadata.Instance.Attributes.DisableAddressManager
 		return disabled
 	}
-	disabled, err = strconv.ParseBool(newMetadata.Project.Attributes.DisableAddressManager)
-	if err == nil {
+	if newMetadata.Project.Attributes.DisableAddressManager != nil {
+		disabled = *newMetadata.Project.Attributes.DisableAddressManager
 		return disabled
 	}
 	return addressDisabled

--- a/GCEWindowsAgent/addresses_test.go
+++ b/GCEWindowsAgent/addresses_test.go
@@ -69,13 +69,13 @@ func TestAddressDisabled(t *testing.T) {
 		{"not explicitly disabled", []byte(""), &metadataJSON{}, false},
 		{"enabled in cfg only", []byte("[addressManager]\ndisable=false"), &metadataJSON{}, false},
 		{"disabled in cfg only", []byte("[addressManager]\ndisable=true"), &metadataJSON{}, true},
-		{"disabled in cfg, enabled in instance metadata", []byte("[addressManager]\ndisable=true"), &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{DisableAddressManager: "false"}}}, true},
-		{"enabled in cfg, disabled in instance metadata", []byte("[addressManager]\ndisable=false"), &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{DisableAddressManager: "true"}}}, false},
-		{"enabled in instance metadata only", []byte(""), &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{DisableAddressManager: "false"}}}, false},
-		{"enabled in project metadata only", []byte(""), &metadataJSON{Project: projectJSON{Attributes: attributesJSON{DisableAddressManager: "false"}}}, false},
-		{"disabled in instance metadata only", []byte(""), &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{DisableAddressManager: "true"}}}, true},
-		{"enabled in instance metadata, disabled in project metadata", []byte(""), &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{DisableAddressManager: "false"}}, Project: projectJSON{Attributes: attributesJSON{DisableAddressManager: "true"}}}, false},
-		{"disabled in project metadata only", []byte(""), &metadataJSON{Project: projectJSON{Attributes: attributesJSON{DisableAddressManager: "true"}}}, true},
+		{"disabled in cfg, enabled in instance metadata", []byte("[addressManager]\ndisable=true"), &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{DisableAddressManager: mkptr(false)}}}, true},
+		{"enabled in cfg, disabled in instance metadata", []byte("[addressManager]\ndisable=false"), &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{DisableAddressManager: mkptr(true)}}}, false},
+		{"enabled in instance metadata only", []byte(""), &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{DisableAddressManager: mkptr(false)}}}, false},
+		{"enabled in project metadata only", []byte(""), &metadataJSON{Project: projectJSON{Attributes: attributesJSON{DisableAddressManager: mkptr(false)}}}, false},
+		{"disabled in instance metadata only", []byte(""), &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{DisableAddressManager: mkptr(true)}}}, true},
+		{"enabled in instance metadata, disabled in project metadata", []byte(""), &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{DisableAddressManager: mkptr(false)}}, Project: projectJSON{Attributes: attributesJSON{DisableAddressManager: mkptr(true)}}}, false},
+		{"disabled in project metadata only", []byte(""), &metadataJSON{Project: projectJSON{Attributes: attributesJSON{DisableAddressManager: mkptr(true)}}}, true},
 	}
 
 	for _, tt := range tests {
@@ -106,13 +106,13 @@ func TestAddressDiff(t *testing.T) {
 		{"not set", []byte(""), &metadataJSON{}, false},
 		{"enabled in cfg only", []byte("[wsfc]\nenable=true"), &metadataJSON{}, true},
 		{"disabled in cfg only", []byte("[wsfc]\nenable=false"), &metadataJSON{}, false},
-		{"disabled in cfg, enabled in instance metadata", []byte("[wsfc]\nenable=false"), &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{EnableWSFC: "true"}}}, false},
-		{"enabled in cfg, disabled in instance metadata", []byte("[wsfc]\nenable=true"), &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{EnableWSFC: "false"}}}, true},
-		{"enabled in instance metadata only", []byte(""), &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{EnableWSFC: "true"}}}, true},
-		{"enabled in project metadata only", []byte(""), &metadataJSON{Project: projectJSON{Attributes: attributesJSON{EnableWSFC: "true"}}}, true},
-		{"disabled in instance metadata only", []byte(""), &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{EnableWSFC: "false"}}}, false},
-		{"enabled in instance metadata, disabled in project metadata", []byte(""), &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{EnableWSFC: "true"}}, Project: projectJSON{Attributes: attributesJSON{EnableWSFC: "false"}}}, true},
-		{"disabled in project metadata only", []byte(""), &metadataJSON{Project: projectJSON{Attributes: attributesJSON{EnableWSFC: "false"}}}, false},
+		{"disabled in cfg, enabled in instance metadata", []byte("[wsfc]\nenable=false"), &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{EnableWSFC: mkptr(true)}}}, false},
+		{"enabled in cfg, disabled in instance metadata", []byte("[wsfc]\nenable=true"), &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{EnableWSFC: mkptr(false)}}}, true},
+		{"enabled in instance metadata only", []byte(""), &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{EnableWSFC: mkptr(true)}}}, true},
+		{"enabled in project metadata only", []byte(""), &metadataJSON{Project: projectJSON{Attributes: attributesJSON{EnableWSFC: mkptr(true)}}}, true},
+		{"disabled in instance metadata only", []byte(""), &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{EnableWSFC: mkptr(false)}}}, false},
+		{"enabled in instance metadata, disabled in project metadata", []byte(""), &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{EnableWSFC: mkptr(true)}}, Project: projectJSON{Attributes: attributesJSON{EnableWSFC: mkptr(false)}}}, true},
+		{"disabled in project metadata only", []byte(""), &metadataJSON{Project: projectJSON{Attributes: attributesJSON{EnableWSFC: mkptr(false)}}}, false},
 	}
 
 	for _, tt := range tests {
@@ -192,7 +192,7 @@ func TestWsfcFlagTriggerAddressDiff(t *testing.T) {
 		oldMetadata = tt.oldMetadata
 		testAddress := addressMgr{}
 		if !testAddress.diff() {
-			t.Errorf("old: %q new: %q doesn't tirgger diff.", tt.oldMetadata, tt.newMetadata)
+			t.Errorf("old: %v new: %v doesn't trigger diff.", tt.oldMetadata, tt.newMetadata)
 		}
 	}
 }
@@ -200,7 +200,7 @@ func TestWsfcFlagTriggerAddressDiff(t *testing.T) {
 func TestAddressLogStatus(t *testing.T) {
 	// Disable it.
 	addressDisabled = false
-	newMetadata = &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{DisableAddressManager: "true"}}}
+	newMetadata = &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{DisableAddressManager: mkptr(true)}}}
 	config = ini.Empty()
 	disabled := (&addressMgr{}).disabled()
 	if !disabled {
@@ -208,7 +208,7 @@ func TestAddressLogStatus(t *testing.T) {
 	}
 
 	// Enable it.
-	newMetadata = &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{DisableAddressManager: "false"}}}
+	newMetadata = &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{DisableAddressManager: mkptr(false)}}}
 	disabled = (&addressMgr{}).disabled()
 	if disabled {
 		t.Fatal("expected false but got", disabled)

--- a/GCEWindowsAgent/diagnostics.go
+++ b/GCEWindowsAgent/diagnostics.go
@@ -74,12 +74,12 @@ func (d *diagnosticsMgr) disabled() (disabled bool) {
 	if err == nil {
 		return !enabled
 	}
-	enabled, err = strconv.ParseBool(newMetadata.Instance.Attributes.EnableDiagnostics)
-	if err == nil {
+	if newMetadata.Instance.Attributes.EnableDiagnostics != nil {
+		enabled = *newMetadata.Instance.Attributes.EnableDiagnostics
 		return !enabled
 	}
-	enabled, err = strconv.ParseBool(newMetadata.Project.Attributes.EnableDiagnostics)
-	if err == nil {
+	if newMetadata.Project.Attributes.EnableDiagnostics != nil {
+		enabled = *newMetadata.Project.Attributes.EnableDiagnostics
 		return !enabled
 	}
 	return diagnosticsDisabled

--- a/GCEWindowsAgent/diagnostics_test.go
+++ b/GCEWindowsAgent/diagnostics_test.go
@@ -49,13 +49,13 @@ func TestDiagnosticsDisabled(t *testing.T) {
 		{"not explicitly enabled", []byte(""), &metadataJSON{}, true},
 		{"enabled in cfg only", []byte("[diagnostics]\nenable=true"), &metadataJSON{}, false},
 		{"disabled in cfg only", []byte("[diagnostics]\nenable=false"), &metadataJSON{}, true},
-		{"disabled in cfg, enabled in instance metadata", []byte("[diagnostics]\nenable=false"), &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{EnableDiagnostics: "true"}}}, true},
-		{"enabled in cfg, disabled in instance metadata", []byte("[diagnostics]\nenable=true"), &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{EnableDiagnostics: "false"}}}, false},
-		{"enabled in instance metadata only", []byte(""), &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{EnableDiagnostics: "true"}}}, false},
-		{"enabled in project metadata only", []byte(""), &metadataJSON{Project: projectJSON{Attributes: attributesJSON{EnableDiagnostics: "true"}}}, false},
-		{"disabled in instance metadata only", []byte(""), &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{EnableDiagnostics: "false"}}}, true},
-		{"enabled in instance metadata, disabled in project metadata", []byte(""), &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{EnableDiagnostics: "true"}}, Project: projectJSON{Attributes: attributesJSON{EnableDiagnostics: "false"}}}, false},
-		{"disabled in project metadata only", []byte(""), &metadataJSON{Project: projectJSON{Attributes: attributesJSON{EnableDiagnostics: "false"}}}, true},
+		{"disabled in cfg, enabled in instance metadata", []byte("[diagnostics]\nenable=false"), &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{EnableDiagnostics: mkptr(true)}}}, true},
+		{"enabled in cfg, disabled in instance metadata", []byte("[diagnostics]\nenable=true"), &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{EnableDiagnostics: mkptr(false)}}}, false},
+		{"enabled in instance metadata only", []byte(""), &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{EnableDiagnostics: mkptr(true)}}}, false},
+		{"enabled in project metadata only", []byte(""), &metadataJSON{Project: projectJSON{Attributes: attributesJSON{EnableDiagnostics: mkptr(true)}}}, false},
+		{"disabled in instance metadata only", []byte(""), &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{EnableDiagnostics: mkptr(false)}}}, true},
+		{"enabled in instance metadata, disabled in project metadata", []byte(""), &metadataJSON{Instance: instanceJSON{Attributes: attributesJSON{EnableDiagnostics: mkptr(true)}}, Project: projectJSON{Attributes: attributesJSON{EnableDiagnostics: mkptr(false)}}}, false},
+		{"disabled in project metadata only", []byte(""), &metadataJSON{Project: projectJSON{Attributes: attributesJSON{EnableDiagnostics: mkptr(false)}}}, true},
 	}
 
 	for _, tt := range tests {

--- a/GCEWindowsAgent/metadata.go
+++ b/GCEWindowsAgent/metadata.go
@@ -19,7 +19,11 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"strconv"
+	"strings"
 	"time"
+
+	"github.com/GoogleCloudPlatform/guest-logging-go/logger"
 )
 
 const defaultEtag = "NONE"
@@ -54,14 +58,83 @@ type projectJSON struct {
 }
 
 type attributesJSON struct {
-	WindowsKeys           string `json:"windows-keys"`
-	Diagnostics           string `json:"diagnostics"`
-	DisableAddressManager string `json:"disable-address-manager"`
-	DisableAccountManager string `json:"disable-account-manager"`
-	EnableDiagnostics     string `json:"enable-diagnostics"`
-	EnableWSFC            string `json:"enable-wsfc"`
-	WSFCAddresses         string `json:"wsfc-addrs"`
-	WSFCAgentPort         string `json:"wsfc-agent-port"`
+	WindowsKeys           windowsKeys
+	Diagnostics           string
+	DisableAddressManager *bool
+	DisableAccountManager *bool
+	EnableDiagnostics     *bool
+	EnableWSFC            *bool
+	WSFCAddresses         string
+	WSFCAgentPort         string
+}
+
+type windowsKey struct {
+	Email        string
+	ExpireOn     string
+	Exponent     string
+	Modulus      string
+	UserName     string
+	HashFunction string
+}
+
+type windowsKeys []windowsKey
+
+func (a *attributesJSON) UnmarshalJSON(b []byte) error {
+	type inner struct {
+		WindowsKeys           windowsKeys `json:"windows-keys"`
+		Diagnostics           string      `json:"diagnostics"`
+		DisableAddressManager string      `json:"disable-address-manager"`
+		DisableAccountManager string      `json:"disable-account-manager"`
+		EnableDiagnostics     string      `json:"enable-diagnostics"`
+		EnableWSFC            string      `json:"enable-wsfc"`
+		WSFCAddresses         string      `json:"wsfc-addrs"`
+		WSFCAgentPort         string      `json:"wsfc-agent-port"`
+	}
+	var temp inner
+	if err := json.Unmarshal(b, &temp); err != nil {
+		return err
+	}
+	a.Diagnostics = temp.Diagnostics
+	a.WSFCAddresses = temp.WSFCAddresses
+	a.WSFCAgentPort = temp.WSFCAgentPort
+	value, err := strconv.ParseBool(temp.DisableAddressManager)
+	if err == nil {
+		a.DisableAddressManager = &value
+	}
+	value, err = strconv.ParseBool(temp.DisableAccountManager)
+	if err == nil {
+		a.DisableAccountManager = &value
+	}
+	value, err = strconv.ParseBool(temp.EnableDiagnostics)
+	if err == nil {
+		a.EnableDiagnostics = &value
+	}
+	value, err = strconv.ParseBool(temp.EnableWSFC)
+	if err == nil {
+		a.EnableWSFC = &value
+	}
+	return nil
+}
+
+func (wks *windowsKeys) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	for _, jskey := range strings.Split(s, "\n") {
+		var wk windowsKey
+		if err := json.Unmarshal([]byte(jskey), &wk); err != nil {
+			if !containsString(jskey, badKeys) {
+				logger.Errorf("failed to unmarshal windows key from metadata: %s", err)
+				badKeys = append(badKeys, jskey)
+			}
+			continue
+		}
+		if wk.Exponent != "" && wk.Modulus != "" && wk.UserName != "" && !wk.expired() {
+			*wks = append(*wks, wk)
+		}
+	}
+	return nil
 }
 
 func updateEtag(resp *http.Response) bool {

--- a/GCEWindowsAgent/metadata_test.go
+++ b/GCEWindowsAgent/metadata_test.go
@@ -32,7 +32,7 @@ func TestWatchMetadata(t *testing.T) {
 		} else {
 			w.Header().Set("etag", etag2)
 		}
-		fmt.Fprintln(w, `{"project":{"attributes":{"windows-keys":"foo"}}}`)
+		fmt.Fprintln(w, `{"project":{"attributes":{"wsfc-addrs":"foo"}}}`)
 		req++
 	}))
 	defer ts.Close()
@@ -48,8 +48,8 @@ func TestWatchMetadata(t *testing.T) {
 			t.Fatalf("error running getMetadata: %v", err)
 		}
 
-		if got.Project.Attributes.WindowsKeys != want {
-			t.Errorf("%q != %q", got.Project.Attributes.WindowsKeys, want)
+		if got.Project.Attributes.WSFCAddresses != want {
+			t.Errorf("%q != %q", got.Project.Attributes.WSFCAddresses, want)
 		}
 
 		if etag != e {

--- a/GCEWindowsAgent/wsfc_test.go
+++ b/GCEWindowsAgent/wsfc_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/go-ini/ini"
 )
 
-func setEnableWSFC(metadata metadataJSON, enabled string) *metadataJSON {
+func setEnableWSFC(metadata metadataJSON, enabled *bool) *metadataJSON {
 	metadata.Instance.Attributes.EnableWSFC = enabled
 	return &metadata
 }
@@ -56,7 +56,7 @@ func TestNewWsfcManager(t *testing.T) {
 		want *wsfcManager
 	}{
 		{"empty meta config", args{&testMetadata}, &wsfcManager{agentNewState: stopped, agentNewPort: wsfcDefaultAgentPort, agent: testAgent}},
-		{"wsfc enabled", args{setEnableWSFC(testMetadata, "true")}, &wsfcManager{agentNewState: running, agentNewPort: wsfcDefaultAgentPort, agent: testAgent}},
+		{"wsfc enabled", args{setEnableWSFC(testMetadata, mkptr(true))}, &wsfcManager{agentNewState: running, agentNewPort: wsfcDefaultAgentPort, agent: testAgent}},
 		{"wsfc addrs is set", args{setWSFCAddresses(testMetadata, "0.0.0.0")}, &wsfcManager{agentNewState: running, agentNewPort: wsfcDefaultAgentPort, agent: testAgent}},
 		{"wsfc port is set", args{setWSFCAgentPort(testMetadata, "1818")}, &wsfcManager{agentNewState: stopped, agentNewPort: "1818", agent: testAgent}},
 	}


### PR DESCRIPTION
This is a preparatory PR for moving linux metadata parsing into this module, first step is to move JSON parsing and logic to custom unmarshaller methods. Decided parsing into base types where possible is best, e.g. *bool instead of *jsonbool or similar so less casting is required¸ but also introduced a new type for the newline-separated JSON object string. Aimed to maintain current testability.