### PR TITLE
Ignore errors in Clear-TempFolders

### DIFF
--- a/gce_base.psm1
+++ b/gce_base.psm1
@@ -111,7 +111,7 @@ function Clear-TempFolders {
     "C:\Users\*\Appdata\LocalLow\Temp\*\*",
     "C:\Users\*\Appdata\LocalLow\Microsoft\Internet Explorer\*") | ForEach-Object {
     if (Test-Path $_) {
-      Remove-Item $_ -recurse -force -ErrorAction SilentlyContinue
+      Remove-Item $_ -Recurse -Force -ErrorAction Ignore
     }
   }
 }


### PR DESCRIPTION
Using ErrorAction SilentlyContinue still generates an error and stores it in the $Error variable. Changing to ErrorAction Ignore suppresses the error completely.