### PR TITLE
Instance setup: Write certs to serial console and Guest Attributes

### DIFF
--- a/google-compute-engine-sysprep.goospec
+++ b/google-compute-engine-sysprep.goospec
@@ -1,6 +1,6 @@
 {
   "name": "google-compute-engine-sysprep",
-  "version": "3.12.0@1",
+  "version": "3.13.0@1",
   "arch": "noarch",
   "authors": "Google Inc.",
   "license": "http://www.apache.org/licenses/LICENSE-2.0",
@@ -16,6 +16,7 @@
     "path": "sysprep_uninstall.ps1"
   },
   "releaseNotes": [
+    "3.11.0- Write certs to serial console and Guest Attributes",
     "3.11.0- Remove features from instance_setup.ps1 that have been moved to the build/GCEAgent",
     "3.10.0- Support BYOL images by skipping GCE activation",
     "3.9.1 - Let gcesysprep pass /f to shutdown.exe to avoid an error on shutdown",

--- a/google-compute-engine-sysprep.goospec
+++ b/google-compute-engine-sysprep.goospec
@@ -16,7 +16,7 @@
     "path": "sysprep_uninstall.ps1"
   },
   "releaseNotes": [
-    "3.11.0- Write certs to serial console and Guest Attributes",
+    "3.13.0- Write certs to serial console and Guest Attributes",
     "3.11.0- Remove features from instance_setup.ps1 that have been moved to the build/GCEAgent",
     "3.10.0- Support BYOL images by skipping GCE activation",
     "3.9.1 - Let gcesysprep pass /f to shutdown.exe to avoid an error on shutdown",


### PR DESCRIPTION
Serial output example:

2020/11/06 18:30:46 GCEInstanceSetup: ------------------------------------------------------------
2020/11/06 18:30:46 GCEInstanceSetup: Instance setup finished. s2019 is ready to use.
2020/11/06 18:30:46 GCEInstanceSetup: ------------------------------------------------------------
2020/11/06 18:30:48 GCEInstanceSetup: WinRM certificate details: Subject: CN=s2019, Thumbprint: 1F2C4097D0226DBA69C18EC3BC1D3E0F2689ED63
2020/11/06 18:30:48 GCEInstanceSetup: RDP certificate details: Subject: CN=s2019, Thumbprint: 0C25B0C9F04839C53CDFB7472E140B7A9CDC0CF2

Guest attributes example:

hostkeys        rdp                   0C25B0C9F04839C53CDFB7472E140B7A9CDC0CF2
hostkeys        winrm                 1F2C4097D0226DBA69C18EC3BC1D3E0F2689ED63