### PR TITLE
Set OSConfig agent service during sysprep

### DIFF
--- a/google-compute-engine-sysprep.goospec
+++ b/google-compute-engine-sysprep.goospec
@@ -1,6 +1,6 @@
 {
   "name": "google-compute-engine-sysprep",
-  "version": "3.14.0@1",
+  "version": "3.15.0@1",
   "arch": "noarch",
   "authors": "Google Inc.",
   "license": "http://www.apache.org/licenses/LICENSE-2.0",
@@ -16,6 +16,9 @@
     "path": "sysprep_uninstall.ps1"
   },
   "releaseNotes": [
+    "3.15.0- Change google_osconfig_agent StartupType:",
+    "      - to Disabled after Sysprep",
+    "      - to Automatic in instance_setup.ps1",
     "3.14.0- Added Windows Server 2016/19 Essentials license keys",
     "3.13.0- Write certs to serial console and Guest Attributes",
     "3.11.0- Remove features from instance_setup.ps1 that have been moved to the build/GCEAgent",

--- a/sysprep/instance_setup.ps1
+++ b/sysprep/instance_setup.ps1
@@ -205,6 +205,9 @@ if (-not ($global:write_to_serial)) {
   Write-Log 'COM1 does not exist on this machine. Logs will not be written to GCE console.'
 }
 
+Write-Log 'Enable google_osconfig_agent during the specialize configuration pass.'
+Set-Service google_osconfig_agent -StartupType Automatic -Verbose -ErrorAction Continue
+
 if ($specialize) {
   Write-Log 'Starting sysprep specialize phase.'
 
@@ -219,9 +222,6 @@ if ($specialize) {
   catch {
     Write-LogError
   }
-
-  Write-Log 'Enable google_osconfig_agent during the specialize configuration pass.'
-  Set-Service google_osconfig_agent -StartupType Automatic -Verbose -ErrorAction Continue
 
   Write-Log 'Finished with sysprep specialize phase, restarting...'
 }

--- a/sysprep/instance_setup.ps1
+++ b/sysprep/instance_setup.ps1
@@ -128,13 +128,13 @@ function Change-InstanceProperties {
   $nics | Invoke-CimMethod -Name SetDNSServerSearchOrder -Arguments @{DNSServerSearchOrder=$null}
   Write-Log 'All networks set to DHCP.'
 
-  $netkvm = Get-CimInstance Win32_NetworkAdapter -filter "ServiceName='netkvm'"	
-  $netkvm | ForEach-Object {	
-    Invoke-ExternalCommand netsh interface ipv4 set interface $_.NetConnectionID mtu=1460 | Out-Null	
-  }	
-  Write-Log 'MTU set to 1460.'	
+  $netkvm = Get-CimInstance Win32_NetworkAdapter -filter "ServiceName='netkvm'"
+  $netkvm | ForEach-Object {
+    Invoke-ExternalCommand netsh interface ipv4 set interface $_.NetConnectionID mtu=1460 | Out-Null
+  }
+  Write-Log 'MTU set to 1460.'
 
-  Invoke-ExternalCommand route /p add 169.254.169.254 mask 255.255.255.255 0.0.0.0 if $netkvm[0].InterfaceIndex metric 1 -ErrorAction SilentlyContinue	
+  Invoke-ExternalCommand route /p add 169.254.169.254 mask 255.255.255.255 0.0.0.0 if $netkvm[0].InterfaceIndex metric 1 -ErrorAction SilentlyContinue
   Write-Log 'Added persistent route to metadata netblock via first netkvm adapter.'
 }
 
@@ -220,6 +220,9 @@ if ($specialize) {
     Write-LogError
   }
 
+  Write-Log 'Enable google_osconfig_agent during the specialize configuration pass.'
+  Set-Service google_osconfig_agent -StartupType Automatic -Verbose -ErrorAction Continue
+
   Write-Log 'Finished with sysprep specialize phase, restarting...'
 }
 else {
@@ -236,4 +239,4 @@ else {
   & $script:activate_instance_script_loc | ForEach-Object {
     Write-Log $_
   }
-} 
+}

--- a/sysprep/sysprep.ps1
+++ b/sysprep/sysprep.ps1
@@ -252,6 +252,8 @@ $PSHome\powershell.exe -NoProfile -NoLogo -ExecutionPolicy Unrestricted -File "$
     exit 0
   }
 
+  Write-Log 'Disable google_osconfig_agent during the specialize configuration pass.'
+  Set-Service google_osconfig_agent -StartupType Disabled -Verbose -ErrorAction Continue
   Write-Log 'Shutting down.'
   Invoke-ExternalCommand shutdown /s /t 00 /d p:2:4 /f
 }


### PR DESCRIPTION
## Summary

OSConfig agent service and policy should run only after sysprep is completed. This PR updates the OSconfig agent service `StartupType` to control the service status.

Also remove unused trailing white spaces with auto-formatter.


## Testing

Tested the command successfully.

```powershell
PS> Set-Service google_osconfig_agent -StartupType Automatic -ErrorAction Continue -Verbose
VERBOSE: Performing the operation "Set-Service" on target "Google OSConfig Agent (google_osconfig_agent)".
```

```powershell
PS> Set-Service google_osconfig_agent -StartupType Disabled -ErrorAction Continue -Verbose
VERBOSE: Performing the operation "Set-Service" on target "Google OSConfig Agent (google_osconfig_agent)".
```