### PR TITLE
Updating Verify-ActivationStatus to correctly return for Unlicensed value

### DIFF
--- a/sysprep/activate_instance.ps1
+++ b/sysprep/activate_instance.ps1
@@ -224,14 +224,15 @@ function Verify-ActivationStatus {
   [String]$status = $null
 
   try {
-    $slmgr_status = & cscript //nologo $env:windir\system32\slmgr.vbs /dli
+    $slmgr_status = & cscript //E:VBScript //nologo $env:windir\system32\slmgr.vbs /dli
   }
   catch {
     return $active
   }
 
   $status = $slmgr_status | Select-String -Pattern '^License Status:'
-  if ($status -match 'Licensed') {
+  # The initial space is to ensure "Unlicensed" does not match.
+  if ($status -match ' Licensed') {
     $active = $true
   }
   return $active


### PR DESCRIPTION
- Updating logic to require a space before the activation status of "Licensed" as the previous logic would match on both "Unlicensed" and "Licensed" values
- Specifying the script engine, as custom images can remove the default value.