### PR TITLE
Update build distro to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 sudo: false
 language: go
 go: stable


### PR DESCRIPTION
The travis CI pipeline fails to run build jobs for the Github compute-image-windows. The cause is the build environment, Ubuntu Trusty (14.04), doesn’t meet the Go 1.16 minimum requirements. The error message is copied below. Similar issue is reported in the [golang github issue 43996](https://github.com/golang/go/issues/43996).

Travis's default build distro is currently xenial: https://docs.travis-ci.com/user/reference/linux/ so changing to it.

Thank you.
