### PR TITLE
Check WinRM status before setup HTTPS listener

### DIFF
--- a/google-compute-engine-sysprep.goospec
+++ b/google-compute-engine-sysprep.goospec
@@ -1,6 +1,6 @@
 {
   "name": "google-compute-engine-sysprep",
-  "version": "3.15.0@1",
+  "version": "3.16.0@1",
   "arch": "noarch",
   "authors": "Google Inc.",
   "license": "http://www.apache.org/licenses/LICENSE-2.0",
@@ -16,6 +16,9 @@
     "path": "sysprep_uninstall.ps1"
   },
   "releaseNotes": [
+    "3.16.0- Ensure WinRM service is started before update HTTPS listener",
+    "      - Set a 5 minutes timeout for WinRM service to start",
+    "      - Throw an error message if WinRM fails to start within 5 minutes",
     "3.15.0- Change google_osconfig_agent StartupType:",
     "      - to Disabled after Sysprep",
     "      - to Automatic in instance_setup.ps1",

--- a/google-compute-engine-sysprep.goospec
+++ b/google-compute-engine-sysprep.goospec
@@ -17,8 +17,8 @@
   },
   "releaseNotes": [
     "3.16.0- Ensure WinRM service is started before update HTTPS listener",
-    "      - Set a 5 minutes timeout for WinRM service to start",
-    "      - Throw an error message if WinRM fails to start within 5 minutes",
+    "      - Set a 2 minutes timeout for WinRM service to start",
+    "      - Throw an error message if WinRM fails to start within 2 minutes",
     "3.15.0- Change google_osconfig_agent StartupType:",
     "      - to Disabled after Sysprep",
     "      - to Automatic in instance_setup.ps1",

--- a/sysprep/instance_setup.ps1
+++ b/sysprep/instance_setup.ps1
@@ -179,7 +179,7 @@ function Configure-WinRM {
 
   try {
     Write-Log 'Waiting for WinRM to be running...'
-    $svcTimeout = '00:05:00'
+    $svcTimeout = '00:02:00'
     $svc = Get-Service -name "WinRM"
     $svc.WaitForStatus('Running',$svcTimeout)
   }

--- a/sysprep/instance_setup.ps1
+++ b/sysprep/instance_setup.ps1
@@ -177,6 +177,17 @@ function Configure-WinRM {
 </p:Listener>
 "@
 
+  try {
+    Write-Log 'Waiting for WinRM to be running...'
+    $svcTimeout = '00:05:00'
+    $svc = Get-Service -name "WinRM"
+    $svc.WaitForStatus('Running',$svcTimeout)
+  }
+  catch {
+    Write-Log 'Error - Could not start WinRM service'
+    return
+  }
+
   $sess = (New-Object -ComObject 'WSMAN.Automation').CreateSession()
   try {
     $sess.Create('winrm/config/listener?Address=*+Transport=HTTPS', $xml)


### PR DESCRIPTION
### Summary

When building custom images with WinRM startupType set to **delayed** the HTTPS listener fails to be updated because WinRM service is not started yet.
This PR ensure that WinRM is in status **Running** before setup HTTPS listener. In case the service is still not started after the specified timeout (5 minutes) an error message is shown in the console.

### Testing

This change has been tested on the following OSes:
- Windows Server 2012r2
- Windows Server 2016
- Windows Server 2019

Below, you can see the console output when it is successful:
```
2021/06/29 08:57:03 GCEInstanceSetup: Renamed from packer-60d9cb43-08ed-bf34-b4a6-e7775f4d0fd5 to osf-test-vm.
2021/06/29 08:57:03 GCEInstanceSetup: Configuring WinRM...
2021/06/29 08:57:05 GCEInstanceSetup: Running 'C:\Program Files\Google\Compute Engine\tools\certgen.exe' with arguments '-outDir C:\Windows\TEMP\cert -hostname osf-test-vm'
2021/06/29 08:57:06 GCEInstanceSetup: --> written C:\Windows\TEMP\cert\cert.p12
2021/06/29 08:57:06 GCEInstanceSetup: Waiting for WinRM to be running...
2021/06/29 08:58:12 GCEInstanceSetup: Setup of WinRM complete.
2021/06/29 08:58:13 GCEMetadataScripts: Starting specialize scripts (version 20200129.00).
```

Below, you can see the console output when an error is thrown:
```
2021/06/29 09:16:47 GCEInstanceSetup: Renamed from packer-60dae1b3-18f8-09f0-7ce4-8c4b64d9b05e to osf-test-vm.
2021/06/29 09:16:47 GCEInstanceSetup: Configuring WinRM...
2021/06/29 09:16:48 GCEInstanceSetup: Running 'C:\Program Files\Google\Compute Engine\tools\certgen.exe' with arguments '-outDir C:\Windows\TEMP\cert -hostname osf-test-vm'
2021/06/29 09:16:50 GCEInstanceSetup: --> written C:\Windows\TEMP\cert\cert.p12
2021/06/29 09:16:50 GCEInstanceSetup: Waiting for WinRM to be running...
2021/06/29 09:17:21 GCEInstanceSetup: Error - Could not start WinRM service
2021/06/29 09:17:22 GCEMetadataScripts: Starting specialize scripts (version 20200129.00).
```