### PR TITLE
replace netsh commands with Powershell equivalents

### DIFF
--- a/sysprep/instance_setup.ps1
+++ b/sysprep/instance_setup.ps1
@@ -161,7 +161,7 @@ function Change-InstanceProperties {
 
   if ($interface -ne $null) {
     $interface | ForEach-Object {
-      Invoke-ExternalCommand netsh interface ipv4 set interface $_.NetConnectionID mtu=1460 | Out-Null
+      Set-NetAdapterAdvancedProperty -InterfaceDescription $_.Name -RegistryKeyword 'MTU' -RegistryValue 1460 | Out-Null
     }
     Write-Log 'MTU set to 1460.'
 

--- a/sysprep/sysprep.ps1
+++ b/sysprep/sysprep.ps1
@@ -244,8 +244,8 @@ $PSHome\powershell.exe -NoProfile -NoLogo -ExecutionPolicy Unrestricted -File "$
   }
 
   Write-Log 'Enable RDP and WinRM firewall rules.'
-  Invoke-ExternalCommand netsh advfirewall firewall add rule profile=any name='Windows Remote Management (HTTPS-In)' dir=in localport=5986 protocol=TCP action=allow
-  Invoke-ExternalCommand netsh advfirewall firewall set rule group='remote desktop' new enable=Yes
+  New-NetFirewallRule -Name "WINRM-HTTPS-In-TCP" -DisplayName 'Windows Remote Management (HTTPS-In)' -Group "Windows Remote Management" -Profile Any -Direction Inbound -LocalPort 5986 -Protocol TCP -Action Allow
+  Set-NetFirewallRule -DisplayGroup "Remote Desktop" -Enabled True
 
   if ($no_shutdown) {
     Write-Log 'GCESysprep complete, not shutting down.'


### PR DESCRIPTION
Update MTU and firewall operations with their Powershell equivalents to avoid netsh (netsh operations are crashing on Win11 23H2)