### PR TITLE
Updating KMS Activation script to exit if instance has BYOL license

### DIFF
--- a/packaging/googet/google-compute-engine-sysprep.goospec
+++ b/packaging/googet/google-compute-engine-sysprep.goospec
@@ -22,7 +22,7 @@
     "path": "sysprep/sysprep_uninstall.ps1"
   },
   "releaseNotes": [
-    "3.18.0- Updated activate_instance.ps1 to skip setting KMS and activation, if any known GCE Windows BYOL license is attached.
+    "3.18.0- Updated activate_instance.ps1 to skip setting KMS and activation, if any known GCE Windows BYOL license is attached.",
     "3.17.0- Add Windows Server 2022 KMS client keys",
     "3.16.0- Ensure WinRM service is started before update HTTPS listener",
     "      - Set a 2 minutes timeout for WinRM service to start",

--- a/packaging/googet/google-compute-engine-sysprep.goospec
+++ b/packaging/googet/google-compute-engine-sysprep.goospec
@@ -22,6 +22,7 @@
     "path": "sysprep/sysprep_uninstall.ps1"
   },
   "releaseNotes": [
+    "3.18.0- Updated activate_instance.ps1 to skip setting KMS and activation, if any known GCE Windows BYOL license is attached.
     "3.17.0- Add Windows Server 2022 KMS client keys",
     "3.16.0- Ensure WinRM service is started before update HTTPS listener",
     "      - Set a 2 minutes timeout for WinRM service to start",

--- a/sysprep/activate_instance.ps1
+++ b/sysprep/activate_instance.ps1
@@ -37,6 +37,7 @@ $byolLicenses.Add('622639362407469665')  # windows-cloud/global/licenses/windows
 $byolLicenses.Add('7036859048284197429') # windows-cloud/global/licenses/windows-8-x64-byol
 $byolLicenses.Add('3720924436396315642') # windows-cloud/global/licenses/windows-8-x86-byol
 $byolLicenses.Add('5366577783322166007') # windows-cloud/global/licenses/windows-81-x64-byol
+$byolLicenses.Add('4551215591257167608') # windows-cloud/global/licenses/windows-server-2008-r2-byol
 $byolLicenses.Add('5559842820536817947') # windows-cloud/global/licenses/windows-server-2012-byol
 $byolLicenses.Add('6738952703547430631') # windows-cloud/global/licenses/windows-server-2012-r2-byol
 $byolLicenses.Add('4322823184804632846') # windows-cloud/global/licenses/windows-server-2016-byol


### PR DESCRIPTION
Updating to PowerShell v3
Added logic to obtain instances GCE licenses from metadata server and immediately exit if any known BYOL license ID is found.