### PR TITLE
Switch to registry based verification

### DIFF
--- a/sysprep/activate_instance.ps1
+++ b/sysprep/activate_instance.ps1
@@ -273,7 +273,7 @@ function Verify-ActivationStatus {
       $slmgr_status = & cscript //E:VBScript //nologo $env:windir\system32\slmgr.vbs /dli
     }
     catch {
-      $active = $false
+      Write-Host "Error getting slmgr license status output."
     }
     $status = $slmgr_status | Select-String -Pattern '^License Status:'
     # The initial space is to ensure "Unlicensed" does not match.
@@ -287,7 +287,7 @@ function Verify-ActivationStatus {
       $activation_status = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\SoftwareProtectionPlatform\Activation" -Name ProductActivationResult).ProductActivationResult
     }
     catch {
-      $active = $false
+      Write-Host "Error retrieving last activation result registry key."
     }
     # Anything other than 0x0 is a failure.
     if ($activation_status -eq '0') {

--- a/sysprep/activate_instance.ps1
+++ b/sysprep/activate_instance.ps1
@@ -273,14 +273,13 @@ function Verify-ActivationStatus {
       $slmgr_status = & cscript //E:VBScript //nologo $env:windir\system32\slmgr.vbs /dli
     }
     catch {
-      return $active
+      $active = $false
     }
     $status = $slmgr_status | Select-String -Pattern '^License Status:'
     # The initial space is to ensure "Unlicensed" does not match.
     if ($status -match ' Licensed') {
       $active = $true
     }
-    return $active
   }
   # All server versions newer than 2008
   else {
@@ -288,14 +287,14 @@ function Verify-ActivationStatus {
       $activation_status = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\SoftwareProtectionPlatform\Activation" -Name ProductActivationResult).ProductActivationResult
     }
     catch {
-      return $active
+      $active = $false
     }
     # Anything other than 0x0 is a failure.
     if ($activation_status -eq '0') {
       $active = $true
     }
-  return $active
   }
+  return $active
 }
 
 function Test-TCPPort {


### PR DESCRIPTION
Except for Server 2008 which doesn't use registry to store status, this will resolve issues with attempting to activate windows when English is not the system display language.