### PR TITLE
Update exclusion of registry to include Server 2012R2

### DIFF
--- a/sysprep/activate_instance.ps1
+++ b/sysprep/activate_instance.ps1
@@ -281,7 +281,7 @@ function Verify-ActivationStatus {
       $active = $true
     }
   }
-  # All server versions newer than 2008
+  # All server versions newer than 2012R2
   else {
     try {
       $activation_status = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\SoftwareProtectionPlatform\Activation" -Name ProductActivationResult).ProductActivationResult

--- a/sysprep/activate_instance.ps1
+++ b/sysprep/activate_instance.ps1
@@ -273,7 +273,7 @@ function Verify-ActivationStatus {
       $slmgr_status = & cscript //E:VBScript //nologo $env:windir\system32\slmgr.vbs /dli
     }
     catch {
-      $active = $false
+      Write-Host "Error getting slmgr license status output."
     }
     $status = $slmgr_status | Select-String -Pattern '^License Status:'
     # The initial space is to ensure "Unlicensed" does not match.
@@ -287,7 +287,7 @@ function Verify-ActivationStatus {
       $activation_status = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\SoftwareProtectionPlatform\Activation" -Name ProductActivationResult).ProductActivationResult
     }
     catch {
-      $active = $false
+      Write-Host "Error retrieving last activation result registry key."
     }
     # Anything other than 0x0 is a failure.
     if ($activation_status -eq '0') {

--- a/sysprep/activate_instance.ps1
+++ b/sysprep/activate_instance.ps1
@@ -273,14 +273,13 @@ function Verify-ActivationStatus {
       $slmgr_status = & cscript //E:VBScript //nologo $env:windir\system32\slmgr.vbs /dli
     }
     catch {
-      return $active
+      $active = $false
     }
     $status = $slmgr_status | Select-String -Pattern '^License Status:'
     # The initial space is to ensure "Unlicensed" does not match.
     if ($status -match ' Licensed') {
       $active = $true
     }
-    return $active
   }
   # All server versions newer than 2008
   else {
@@ -288,14 +287,14 @@ function Verify-ActivationStatus {
       $activation_status = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\SoftwareProtectionPlatform\Activation" -Name ProductActivationResult).ProductActivationResult
     }
     catch {
-      return $active
+      $active = $false
     }
     # Anything other than 0x0 is a failure.
     if ($activation_status -eq '0') {
       $active = $true
     }
-  return $active
   }
+  return $active
 }
 
 function Test-TCPPort {

--- a/sysprep/activate_instance.ps1
+++ b/sysprep/activate_instance.ps1
@@ -267,19 +267,20 @@ function Verify-ActivationStatus {
   [String]$status = $null
 
   # Server 2008 doesn't store activation status in registry; check slmgr
-  if([Environment]::OSVersion.Version.Major -eq 6 -and [Environment]::OSVersion.Version.Minor -le 1)
+  if([Environment]::OSVersion.Version.Major -eq 6 -and [Environment]::OSVersion.Version.Minor -le 3)
   {
     try {
       $slmgr_status = & cscript //E:VBScript //nologo $env:windir\system32\slmgr.vbs /dli
     }
     catch {
-      Write-Host "Error getting slmgr license status output."
+      return $active
     }
     $status = $slmgr_status | Select-String -Pattern '^License Status:'
     # The initial space is to ensure "Unlicensed" does not match.
     if ($status -match ' Licensed') {
       $active = $true
     }
+    return $active
   }
   # All server versions newer than 2008
   else {
@@ -287,14 +288,14 @@ function Verify-ActivationStatus {
       $activation_status = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\SoftwareProtectionPlatform\Activation" -Name ProductActivationResult).ProductActivationResult
     }
     catch {
-      Write-Host "Error retrieving last activation result registry key."
+      return $active
     }
     # Anything other than 0x0 is a failure.
     if ($activation_status -eq '0') {
       $active = $true
     }
-  }
   return $active
+  }
 }
 
 function Test-TCPPort {


### PR DESCRIPTION
Turns out the registry directory gets created but there is no definitive last activation result key. It is OK to continue to use string matching for this since 2012R2 is already EOS.