### PR TITLE
Update note on using slmgr

### DIFF
--- a/sysprep/activate_instance.ps1
+++ b/sysprep/activate_instance.ps1
@@ -266,7 +266,7 @@ function Verify-ActivationStatus {
   [String]$activation_status = $null
   [String]$status = $null
 
-  # Server 2008 doesn't store activation status in registry; check slmgr
+  # Server 2008/2012R2 don't store activation status in registry; check slmgr
   if([Environment]::OSVersion.Version.Major -eq 6 -and [Environment]::OSVersion.Version.Minor -le 3)
   {
     try {


### PR DESCRIPTION
Add 2012R2 as skipped. Missed this in the last PR.