### PR TITLE
Add gvnic driver 1.1 support to instance_setup.ps1

### DIFF
--- a/packaging/googet/google-compute-engine-sysprep.goospec
+++ b/packaging/googet/google-compute-engine-sysprep.goospec
@@ -22,6 +22,7 @@
     "path": "sysprep/sysprep_uninstall.ps1"
   },
   "releaseNotes": [
+    "3.22.0 - Updating instance_setup.ps1 to support gvnic v1.1 driver.",
     "3.21.0 - Updating activate_instance.ps1.",
     "3.20.0 - Remove MTLS MDS certificates from certificate store and disk during sysprep.",
     "3.19.0 - Migrating MTU & Firewall rule modifications to use PowerShell cmdlets instead of netsh for Win10/2016 and above.",


### PR DESCRIPTION
If the gvnic driver is below 1.1 - set settings based on GQ driver requirements
If the gvnic driver is 1.1 or above - set settings based on DQ driver requirements