### PR TITLE
Update AKC to use compat manager if it exists

### DIFF
--- a/ssh/install.ps1
+++ b/ssh/install.ps1
@@ -30,8 +30,20 @@ param (
 # Configuration Data
 $start_pattern = '# Start Google Added Lines'
 $end_pattern = '# End Google Added Lines'
-$akc_path = '"C:/Program Files/Google/Compute Engine/agent/GCEAuthorizedKeysCommand.exe"'
 $sshd_config_path = 'C:\ProgramData\ssh\sshd_config'
+
+# Google Authorized Keys command.
+$akc_path = '"C:/Program Files/Google/Compute Engine/agent/GCEAuthorizedKeysCommand.exe"'
+$akc_compat = '"C:/Program Files/Google/Compute Engine/agent/GCEAuthorizedKeysCompat.exe"'
+$akc_v2 = '"C:/Program Files/Google/Compute Engine/agent/GCEAuthorizedKeys.exe"'
+
+If (Test-Path $akc_v2) {
+        $akc_path = $akc_v2
+}
+
+If (Test-Path $akc_compat) {
+        $akc_path = $akc_compat
+}
 
 $sshd_config_text = @"
 

--- a/ssh/install.ps1
+++ b/ssh/install.ps1
@@ -34,15 +34,15 @@ $sshd_config_path = 'C:\ProgramData\ssh\sshd_config'
 
 # Google Authorized Keys command.
 $akc_path = '"C:/Program Files/Google/Compute Engine/agent/GCEAuthorizedKeysCommand.exe"'
-$akc_compat = '"C:/Program Files/Google/Compute Engine/agent/GCEAuthorizedKeysCompat.exe"'
-$akc_v2 = '"C:/Program Files/Google/Compute Engine/agent/GCEAuthorizedKeys.exe"'
+$akc_compat = "C:/Program Files/Google/Compute Engine/agent/GCEAuthorizedKeysCompat.exe"
+$akc_v2 = "C:/Program Files/Google/Compute Engine/agent/GCEAuthorizedKeys.exe"
 
 If (Test-Path $akc_v2) {
-        $akc_path = $akc_v2
+        $akc_path = """$akc_v2"""
 }
 
 If (Test-Path $akc_compat) {
-        $akc_path = $akc_compat
+        $akc_path = """$akc_compat"""
 }
 
 $sshd_config_text = @"


### PR DESCRIPTION
This is for compatibility with the side-by-side packaging of the new and old guest agents. The compat manager will determine which AKC to run based on the metadata.

/hold
/cc @ChaitanyaKulkarni28 @dorileo 