### PR TITLE
use adapt script from agent instead for launching metadata script

### DIFF
--- a/sysprep/instance_setup.ps1
+++ b/sysprep/instance_setup.ps1
@@ -41,15 +41,10 @@ $script:setupcomplete_loc = "$env:WinDir\Setup\Scripts\SetupComplete.cmd"
 $script:write_to_serial = $false
 
 $script:metadata_script_loc = "$script:gce_install_dir\metadata_scripts\GCEMetadataScripts.exe"
-$script:compatRunner = "$script:gce_install_dir\metadata_scripts\GCECompatMetadataScripts.exe"
-$script:runnerV2 = "$script:gce_install_dir\agent\GCEMetadataScriptRunner.exe"
+$script:runnerV2 = "$script:gce_install_dir\agent\google_metadata_script_runner_adapt.ps1"
 
 if (Test-Path $script:runnerV2) {
   $script:metadata_script_loc = $script:runnerV2
-}
-
-if (Test-Path $script:compatRunner) {
-  $script:metadata_script_loc = $script:compatRunner
 }
 
 try {


### PR DESCRIPTION
Script logic is moved to centralized place in guest-agent repo in [PR](https://github.com/GoogleCloudPlatform/guest-agent/pull/569)

/cc @dorileo @drewhli 